### PR TITLE
Continuous compliance notification resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,10 @@
-## 1.11.2 (Unreleased)
+## 1.11.3 (Unreleased)
+
+## 1.11.2 (October 31, 2019)
+
+FEATURES:
+
+* **New Resource:** `dome9_continuous_compliance_notification`
+* **New Data Source:** `dome9_continuous_compliance_notification`
+
 ## 1.11.1 (October 28, 2019)

--- a/dome9/common/resourcetype/resource_type.go
+++ b/dome9/common/resourcetype/resource_type.go
@@ -6,6 +6,6 @@ const (
 	CloudAccountAzure                = "dome9_cloudaccount_azure"
 	CloudAccountGCP                  = "dome9_cloudaccount_gcp"
 	IPList                           = "dome9_iplist"
-	ContinuousCompliancePolicy       = "dome9_continuouscompliance_policy"
-	ContinuousComplianceNotification = "dome9_continuouscompliance_notification"
+	ContinuousCompliancePolicy       = "dome9_continuous_compliance_policy"
+	ContinuousComplianceNotification = "dome9_continuous_compliance_notification"
 )

--- a/dome9/common/resourcetype/resource_type.go
+++ b/dome9/common/resourcetype/resource_type.go
@@ -2,9 +2,10 @@ package resourcetype
 
 // dome9 Types
 const (
-	CloudAccountAWS            = "dome9_cloudaccount_aws"
-	CloudAccountAzure          = "dome9_cloudaccount_azure"
-	CloudAccountGCP            = "dome9_cloudaccount_gcp"
-	IPList                     = "dome9_iplist"
-	ContinuousCompliancePolicy = "dome9_continuouscompliance_policy"
+	CloudAccountAWS                  = "dome9_cloudaccount_aws"
+	CloudAccountAzure                = "dome9_cloudaccount_azure"
+	CloudAccountGCP                  = "dome9_cloudaccount_gcp"
+	IPList                           = "dome9_iplist"
+	ContinuousCompliancePolicy       = "dome9_continuouscompliance_policy"
+	ContinuousComplianceNotification = "dome9_continuouscompliance_notification"
 )

--- a/dome9/common/testing/environmentvariable/environment_variable.go
+++ b/dome9/common/testing/environmentvariable/environment_variable.go
@@ -32,5 +32,6 @@ const (
 
 // Continuous Compliance Policy environment variable
 const (
-	ContinuousCompliancePolicyEnvVarNotificationId = "CONTINUOUS_COMPLIANCE_NOTIFICATION_ID"
+	ContinuousCompliancePolicyEnvVarNotificationId1 = "CONTINUOUS_COMPLIANCE_NOTIFICATION_ID1"
+	ContinuousCompliancePolicyEnvVarNotificationId2 = "CONTINUOUS_COMPLIANCE_NOTIFICATION_ID2"
 )

--- a/dome9/common/testing/variable/variable.go
+++ b/dome9/common/testing/variable/variable.go
@@ -36,3 +36,21 @@ const (
 	IPListDescriptionResource       = "acceptance-test"
 	IPListUpdateDescriptionResource = "update-acceptance-test"
 )
+
+// Continuous Compliance Notification resource/data source
+const (
+	ContinuousComplianceNotificationName               = "test_notification"
+	ContinuousComplianceNotificationDescription        = "this notification for testing"
+	ContinuousComplianceNotificationAlertsConsole      = true
+	ContinuousComplianceNotificationEnabled            = "Enabled"
+	ContinuousComplianceNotificationDisabled           = "Disabled"
+	ContinuousComplianceNotificationCronExpression     = "0 0 10 1/1 * ? *"
+	ContinuousComplianceNotificationType               = "Detailed"
+	ContinuousComplianceNotificationRecipient          = "test@test.com"
+	ContinuousComplianceNotificationJsonWithFullEntity = "JsonWithFullEntity"
+
+	// Update const
+	ContinuousComplianceNotificationUpdateName          = "test_notification_update"
+	ContinuousComplianceNotificationUpdateDescription   = "this notification for update testing"
+	ContinuousComplianceNotificationUpdateAlertsConsole = false
+)

--- a/dome9/config.go
+++ b/dome9/config.go
@@ -7,16 +7,18 @@ import (
 	"github.com/dome9/dome9-sdk-go/services/cloudaccounts/aws"
 	"github.com/dome9/dome9-sdk-go/services/cloudaccounts/azure"
 	"github.com/dome9/dome9-sdk-go/services/cloudaccounts/gcp"
+	"github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_notification"
 	"github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_policy"
 	"github.com/dome9/dome9-sdk-go/services/iplist"
 )
 
 type Client struct {
-	iplist                     iplist.Service
-	cloudaccountAWS            aws.Service
-	cloudaccountAzure          azure.Service
-	cloudaccountGCP            gcp.Service
-	continuousCompliancePolicy continuous_compliance_policy.Service
+	iplist                           iplist.Service
+	cloudaccountAWS                  aws.Service
+	cloudaccountAzure                azure.Service
+	cloudaccountGCP                  gcp.Service
+	continuousCompliancePolicy       continuous_compliance_policy.Service
+	continuousComplianceNotification continuous_compliance_notification.Service
 }
 
 type Config struct {
@@ -34,11 +36,12 @@ func (c *Config) Client() (*Client, error) {
 	}
 
 	client := &Client{
-		iplist:                     *iplist.New(config),
-		cloudaccountAWS:            *aws.New(config),
-		cloudaccountAzure:          *azure.New(config),
-		cloudaccountGCP:            *gcp.New(config),
-		continuousCompliancePolicy: *continuous_compliance_policy.New(config),
+		iplist:                           *iplist.New(config),
+		cloudaccountAWS:                  *aws.New(config),
+		cloudaccountAzure:                *azure.New(config),
+		cloudaccountGCP:                  *gcp.New(config),
+		continuousCompliancePolicy:       *continuous_compliance_policy.New(config),
+		continuousComplianceNotification: *continuous_compliance_notification.New(config),
 	}
 
 	log.Println("initialized client")

--- a/dome9/data_source_dome9_cloudaccount_aws.go
+++ b/dome9/data_source_dome9_cloudaccount_aws.go
@@ -84,12 +84,12 @@ func dataSourceCloudAccountAWS() *schema.Resource {
 }
 
 func dataSourceAWSRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	d9Client := meta.(*Client)
 
 	id := d.Get("id").(string)
 	log.Printf("[INFO] Getting data for cloud account %s with id %s\n", variable.CloudAccountAWSVendor, id)
 
-	resp, _, err := client.cloudaccountAWS.Get(cloudaccounts.QueryParameters{ID: id})
+	resp, _, err := d9Client.cloudaccountAWS.Get(cloudaccounts.QueryParameters{ID: id})
 	if err != nil {
 		return err
 	}

--- a/dome9/data_source_dome9_cloudaccount_aws_test.go
+++ b/dome9/data_source_dome9_cloudaccount_aws_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceCloudAccountAWSBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccCloudAccountAWSPreCheck(t)
+			testAccCloudAccountAWSEnvVarsPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudAccountDestroy,

--- a/dome9/data_source_dome9_cloudaccount_azure.go
+++ b/dome9/data_source_dome9_cloudaccount_azure.go
@@ -15,7 +15,7 @@ func dataSourceCloudAccountAzure() *schema.Resource {
 		Read: dataSourceAzureRead,
 
 		Schema: map[string]*schema.Schema{
-			"account_id": {
+			"id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -60,12 +60,12 @@ func dataSourceCloudAccountAzure() *schema.Resource {
 }
 
 func dataSourceAzureRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	d9Client := meta.(*Client)
 
-	id := d.Get("account_id").(string)
+	id := d.Get("id").(string)
 	log.Printf("Getting data for cloud account %s with id %s\n", variable.CloudAccountAzureVendor, id)
 
-	azureCloudAccount, _, err := client.cloudaccountAzure.Get(cloudaccounts.QueryParameters{ID: id})
+	azureCloudAccount, _, err := d9Client.cloudaccountAzure.Get(cloudaccounts.QueryParameters{ID: id})
 	if err != nil {
 		return err
 	}

--- a/dome9/data_source_dome9_cloudaccount_azure_test.go
+++ b/dome9/data_source_dome9_cloudaccount_azure_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccDataSourceCloudAccountAzureBasic(t *testing.T) {
 	resourceTypeAndName, dataSourceTypeAndName, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.CloudAccountAzure)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/dome9/data_source_dome9_cloudaccount_gcp.go
+++ b/dome9/data_source_dome9_cloudaccount_gcp.go
@@ -15,7 +15,7 @@ func dataSourceCloudAccountGCP() *schema.Resource {
 		Read: dataSourceGCPRead,
 
 		Schema: map[string]*schema.Schema{
-			"account_id": {
+			"id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -60,12 +60,12 @@ func dataSourceCloudAccountGCP() *schema.Resource {
 }
 
 func dataSourceGCPRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	d9Client := meta.(*Client)
 
-	id := d.Get("account_id").(string)
+	id := d.Get("id").(string)
 	log.Printf("Getting data for %s cloud account with id %s\n", variable.CloudAccountGCPVendor, id)
 
-	GCPCloudAccount, _, err := client.cloudaccountGCP.Get(cloudaccounts.QueryParameters{ID: id})
+	GCPCloudAccount, _, err := d9Client.cloudaccountGCP.Get(cloudaccounts.QueryParameters{ID: id})
 	if err != nil {
 		return err
 	}

--- a/dome9/data_source_dome9_cloudaccount_gcp_test.go
+++ b/dome9/data_source_dome9_cloudaccount_gcp_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccDataSourceCloudAccountGCPBasic(t *testing.T) {
 	resourceTypeAndName, dataSourceTypeAndName, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.CloudAccountGCP)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/dome9/data_source_dome9_continuous_compliance_notification.go
+++ b/dome9/data_source_dome9_continuous_compliance_notification.go
@@ -1,0 +1,287 @@
+package dome9
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceContinuousComplianceNotification() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceContinuousComplianceNotificationRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alerts_console": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"scheduled_report": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email_sending_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cron_expression": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"recipients": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"change_detection": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email_sending_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email_per_finding_sending_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sns_sending_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_ticket_creating_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"aws_security_hub_integration_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"webhook_integration_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"recipients": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+						"email_per_finding_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"recipients": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"notification_output_format": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"sns_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"sns_topic_arn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"sns_output_format": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ticketing_system_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"system_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"should_close_tickets": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"domain": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"pass": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"project_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"issue_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"aws_security_hub_integration": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"external_account_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"webhook_data": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"http_method": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"auth_method": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"password": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"format_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"gcp_security_command_center_integration": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceContinuousComplianceNotificationRead(d *schema.ResourceData, meta interface{}) error {
+	d9Client := meta.(*Client)
+
+	id := d.Get("id").(string)
+	log.Printf("[INFO] Getting data for continuous compliance notification with id %s\n", id)
+
+	resp, _, err := d9Client.continuousComplianceNotification.Get(id)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resp.ID)
+	_ = d.Set("name", resp.Name)
+	_ = d.Set("description", resp.Description)
+	_ = d.Set("alerts_console", resp.AlertsConsole)
+
+	if resp.ScheduledReport != nil {
+		if err := d.Set("scheduled_report", flattenScheduledReport(resp.ScheduledReport)); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("change_detection", flattenChangeDetection(&resp.ChangeDetection)); err != nil {
+		return err
+	}
+
+	if resp.GCPSecurityCommandCenterIntegration != nil {
+		if err = d.Set("gcp_security_command_center_integration", flattenGCPSecurityCommandCenterIntegration(resp.GCPSecurityCommandCenterIntegration)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/dome9/data_source_dome9_continuous_compliance_notification_test.go
+++ b/dome9/data_source_dome9_continuous_compliance_notification_test.go
@@ -1,0 +1,35 @@
+package dome9
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/resourcetype"
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/method"
+)
+
+func TestAccDataSourceNotificationBasic(t *testing.T) {
+	resourceTypeAndName, dataSourceTypeAndName, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContinuousComplianceNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, continuousComplianceNotificationConfig()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "id", resourceTypeAndName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "name", resourceTypeAndName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "description", resourceTypeAndName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "alerts_console", resourceTypeAndName, "alerts_console"),
+					resource.TestCheckResourceAttr(dataSourceTypeAndName, "scheduled_report.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceTypeAndName, "change_detection.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/dome9/data_source_dome9_continuous_compliance_notification_test.go
+++ b/dome9/data_source_dome9_continuous_compliance_notification_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/method"
 )
 
-func TestAccDataSourceNotificationBasic(t *testing.T) {
+func TestAccDataSourceContinuousComplianceNotificationBasic(t *testing.T) {
 	resourceTypeAndName, dataSourceTypeAndName, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
 
 	resource.Test(t, resource.TestCase{

--- a/dome9/data_source_dome9_continuous_compliance_policy.go
+++ b/dome9/data_source_dome9_continuous_compliance_policy.go
@@ -41,11 +41,12 @@ func dataSourceContinuousCompliancePolicy() *schema.Resource {
 }
 
 func dataSourceContinuousCompliancePolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	d9Client := meta.(*Client)
+
 	policyID := d.Get("id").(string)
 	log.Printf("Getting data for Continuous Compliance Policy id: %s\n", policyID)
 
-	resp, _, err := client.continuousCompliancePolicy.Get(policyID)
+	resp, _, err := d9Client.continuousCompliancePolicy.Get(policyID)
 	if err != nil {
 		return err
 	}

--- a/dome9/data_source_dome9_continuous_compliance_policy_test.go
+++ b/dome9/data_source_dome9_continuous_compliance_policy_test.go
@@ -7,11 +7,17 @@ import (
 
 	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/resourcetype"
 	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/method"
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/variable"
 )
 
 func TestAccDataSourceContinuousCompliancePolicyBasic(t *testing.T) {
-	policyResourceTypeAndName, policyDataSourceTypeAndName, policyGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousCompliancePolicy)
-	cloudAccountResourceTypeAndName, _, cloudAccountGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.CloudAccountAzure)
+	policyTypeAndName, policyDataSourceTypeAndName, policyGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousCompliancePolicy)
+	azureTypeAndName, _, azureGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.CloudAccountAzure)
+	notificationTypeAndName, _, notificationGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
+
+	azureHCL := getCloudAccountAzureResourceHCL(azureGeneratedName, variable.CloudAccountAzureCreationResourceName)
+	notificationHCL := getContinuousComplianceNotificationResourceHCL(notificationGeneratedName, continuousComplianceNotificationConfig())
+	policyHCL := getContinuousCompliancePolicyResourceHCL(azureHCL, azureTypeAndName, notificationHCL, notificationTypeAndName, policyGeneratedName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -22,10 +28,10 @@ func TestAccDataSourceContinuousCompliancePolicyBasic(t *testing.T) {
 		CheckDestroy: testAccCheckContinuousCompliancePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckContinuousCompliancePolicyBasic(policyGeneratedName, cloudAccountGeneratedName, cloudAccountResourceTypeAndName, policyResourceTypeAndName, getNotificationIDsConfig()),
+				Config: testAccCheckContinuousCompliancePolicyBasic(policyHCL, policyGeneratedName, policyTypeAndName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "id", policyResourceTypeAndName, "id"),
-					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "cloud_account_id", policyResourceTypeAndName, "cloud_account_id"),
+					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "id", policyTypeAndName, "id"),
+					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "cloud_account_id", policyTypeAndName, "cloud_account_id"),
 					resource.TestCheckResourceAttr(policyDataSourceTypeAndName, "cloud_account_type", "Azure"),
 					resource.TestCheckResourceAttr(policyDataSourceTypeAndName, "notification_ids.#", "1"),
 				),

--- a/dome9/data_source_dome9_continuous_compliance_policy_test.go
+++ b/dome9/data_source_dome9_continuous_compliance_policy_test.go
@@ -17,13 +17,12 @@ func TestAccDataSourceContinuousCompliancePolicyBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccCloudAccountAzureEnvVarsPreCheck(t) // Azure account used as an input for policy creation thus this check is required
-			testAccContinuousCompliancePolicyEnvVarsPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContinuousCompliancePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckContinuousCompliancePolicyBasic(policyGeneratedName, cloudAccountGeneratedName, cloudAccountResourceTypeAndName, policyResourceTypeAndName),
+				Config: testAccCheckContinuousCompliancePolicyBasic(policyGeneratedName, cloudAccountGeneratedName, cloudAccountResourceTypeAndName, policyResourceTypeAndName, getNotificationIDsConfig()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "id", policyResourceTypeAndName, "id"),
 					resource.TestCheckResourceAttrPair(policyDataSourceTypeAndName, "cloud_account_id", policyResourceTypeAndName, "cloud_account_id"),

--- a/dome9/data_source_dome9_iplist.go
+++ b/dome9/data_source_dome9_iplist.go
@@ -48,13 +48,14 @@ func dataSourceIpList() *schema.Resource {
 }
 
 func dataSourceIpListRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	d9Client := meta.(*Client)
+
 	id, err := strconv.ParseInt(d.Get("id").(string), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	ipList, _, err := client.iplist.Get(id)
+	ipList, _, err := d9Client.iplist.Get(id)
 	if err != nil {
 		return err
 	}

--- a/dome9/data_source_dome9_iplist_test.go
+++ b/dome9/data_source_dome9_iplist_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccDataSourceIpListBasic(t *testing.T) {
 	resourceTypeAndName, dataSourceTypeAndName, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.IPList)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/dome9/provider.go
+++ b/dome9/provider.go
@@ -37,19 +37,21 @@ func Provider() terraform.ResourceProvider {
 				terraform resource name: resource schema
 				resource formation: provider-resourcename-subresource
 			*/
-			resourcetype.IPList:                     resourceIpList(),
-			resourcetype.CloudAccountAWS:            resourceCloudAccountAWS(),
-			resourcetype.CloudAccountGCP:            resourceCloudAccountGCP(),
-			resourcetype.CloudAccountAzure:          resourceCloudAccountAzure(),
-			resourcetype.ContinuousCompliancePolicy: resourceContinuousCompliancePolicy(),
+			resourcetype.IPList:                           resourceIpList(),
+			resourcetype.CloudAccountAWS:                  resourceCloudAccountAWS(),
+			resourcetype.CloudAccountGCP:                  resourceCloudAccountGCP(),
+			resourcetype.CloudAccountAzure:                resourceCloudAccountAzure(),
+			resourcetype.ContinuousCompliancePolicy:       resourceContinuousCompliancePolicy(),
+			resourcetype.ContinuousComplianceNotification: resourceContinuousComplianceNotification(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			// terraform date source name: data source schema
-			resourcetype.IPList:                     dataSourceIpList(),
-			resourcetype.CloudAccountAWS:            dataSourceCloudAccountAWS(),
-			resourcetype.CloudAccountGCP:            dataSourceCloudAccountGCP(),
-			resourcetype.CloudAccountAzure:          dataSourceCloudAccountAzure(),
-			resourcetype.ContinuousCompliancePolicy: dataSourceContinuousCompliancePolicy(),
+			resourcetype.IPList:                           dataSourceIpList(),
+			resourcetype.CloudAccountAWS:                  dataSourceCloudAccountAWS(),
+			resourcetype.CloudAccountGCP:                  dataSourceCloudAccountGCP(),
+			resourcetype.CloudAccountAzure:                dataSourceCloudAccountAzure(),
+			resourcetype.ContinuousCompliancePolicy:       dataSourceContinuousCompliancePolicy(),
+			resourcetype.ContinuousComplianceNotification: dataSourceContinuousComplianceNotification(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/dome9/resource_dome9_cloudaccount_aws_test.go
+++ b/dome9/resource_dome9_cloudaccount_aws_test.go
@@ -29,7 +29,7 @@ func TestAccResourceCloudAccountAWSBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccCloudAccountAWSPreCheck(t)
+			testAccCloudAccountAWSEnvVarsPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudAccountDestroy,
@@ -88,7 +88,7 @@ func testAccCheckCloudAccountAWSExists(resource string, cloudAccount *aws.CloudA
 	}
 }
 
-func testAccCloudAccountAWSPreCheck(t *testing.T) {
+func testAccCloudAccountAWSEnvVarsPreCheck(t *testing.T) {
 	if v := os.Getenv(environmentvariable.CloudAccountAWSEnvVarArn); v == "" {
 		t.Fatalf("%s must be set for acceptance tests", environmentvariable.CloudAccountAWSEnvVarArn)
 	}
@@ -141,7 +141,7 @@ data "%s" "%s" {
 }
 
 `,
-		// resource variable
+		// resource variables
 		resourcetype.CloudAccountAWS,
 		generatedName,
 		resourceName,
@@ -149,7 +149,7 @@ data "%s" "%s" {
 		os.Getenv(environmentvariable.CloudAccountAWSEnvVarSecret),
 		additionalBlock,
 
-		// data source variable
+		// data source variables
 		resourcetype.CloudAccountAWS,
 		generatedName,
 		resourceTypeAndName,

--- a/dome9/resource_dome9_cloudaccount_azure.go
+++ b/dome9/resource_dome9_cloudaccount_azure.go
@@ -20,6 +20,7 @@ func resourceCloudAccountAzure() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/dome9/resource_dome9_cloudaccount_azure_test.go
+++ b/dome9/resource_dome9_cloudaccount_azure_test.go
@@ -118,22 +118,38 @@ func testAccCheckCloudAccountAzureExists(resource string, resp *azure.CloudAccou
 
 func testAccCheckCloudAccountAzureConfigure(resourceTypeAndName, generatedName, resourceName string) string {
 	return fmt.Sprintf(`
+// azure cloud account creation
+%s
+
+data "%s" "%s" {
+  id = "${%s.id}"
+}
+`,
+		// azure cloud account
+		getCloudAccountAzureConfig(generatedName, resourceName),
+
+		// data source variables
+		resourcetype.CloudAccountAzure,
+		generatedName,
+		resourceTypeAndName,
+	)
+}
+
+func getCloudAccountAzureConfig(generatedName, resourceName string) string {
+	return fmt.Sprintf(`
 resource "%s" "%s" {
   credentials = {
-    client_id = "%s"
+    client_id       = "%s"
     client_password = "%s"
   }
 
-  name = "%s"
-  operation_mode = "%s"
+  name            = "%s"
+  operation_mode  = "%s"
   subscription_id = "%s"
-  tenant_id = "%s"
-}
-data "%s" "%s" {
-  account_id = "${%s.id}"
+  tenant_id       = "%s"
 }
 `,
-		// resource variable
+		// azure cloud account variables
 		resourcetype.CloudAccountAzure,
 		generatedName,
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarClientId),
@@ -142,10 +158,5 @@ data "%s" "%s" {
 		variable.CloudAccountAzureOperationMode,
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarSubscriptionId),
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarTenantId),
-
-		// data source variable
-		resourcetype.CloudAccountAzure,
-		generatedName,
-		resourceTypeAndName,
 	)
 }

--- a/dome9/resource_dome9_cloudaccount_azure_test.go
+++ b/dome9/resource_dome9_cloudaccount_azure_test.go
@@ -126,7 +126,7 @@ data "%s" "%s" {
 }
 `,
 		// azure cloud account
-		getCloudAccountAzureConfig(generatedName, resourceName),
+		getCloudAccountAzureResourceHCL(generatedName, resourceName),
 
 		// data source variables
 		resourcetype.CloudAccountAzure,
@@ -135,7 +135,7 @@ data "%s" "%s" {
 	)
 }
 
-func getCloudAccountAzureConfig(generatedName, resourceName string) string {
+func getCloudAccountAzureResourceHCL(cloudAccountName, generatedAName string) string {
 	return fmt.Sprintf(`
 resource "%s" "%s" {
   credentials = {
@@ -151,10 +151,10 @@ resource "%s" "%s" {
 `,
 		// azure cloud account variables
 		resourcetype.CloudAccountAzure,
-		generatedName,
+		cloudAccountName,
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarClientId),
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarClientPassword),
-		resourceName,
+		generatedAName,
 		variable.CloudAccountAzureOperationMode,
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarSubscriptionId),
 		os.Getenv(environmentvariable.CloudAccountAzureEnvVarTenantId),

--- a/dome9/resource_dome9_cloudaccount_gcp.go
+++ b/dome9/resource_dome9_cloudaccount_gcp.go
@@ -221,6 +221,7 @@ func expandCloudAccountGCPRequest(d *schema.ResourceData) gcp.CloudAccountReques
 		GsuiteUser:                d.Get("gsuite_user").(string),
 		DomainName:                d.Get("domain_name").(string),
 	}
+
 	return req
 }
 

--- a/dome9/resource_dome9_cloudaccount_gcp_test.go
+++ b/dome9/resource_dome9_cloudaccount_gcp_test.go
@@ -135,10 +135,10 @@ resource "%s" "%s" {
 }
 
 data "%s" "%s" {
-  account_id = "${%s.id}"
+  id = "${%s.id}"
 }
 `,
-		// resource variable
+		// resource variables
 		resourcetype.CloudAccountGCP,
 		generatedName,
 		resourceName,
@@ -153,7 +153,7 @@ data "%s" "%s" {
 		variable.CloudAccountGCPAuthProviderX509CertURL,
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarClientX509CertUrl),
 
-		// data source variable
+		// data source variables
 		resourcetype.CloudAccountGCP,
 		generatedName,
 		resourceTypeAndName,

--- a/dome9/resource_dome9_continuous_compliance_notification.go
+++ b/dome9/resource_dome9_continuous_compliance_notification.go
@@ -370,7 +370,7 @@ func resourceContinuousComplianceNotificationDelete(d *schema.ResourceData, meta
 	if _, err := d9Client.continuousComplianceNotification.Delete(d.Id()); err != nil {
 		return err
 	}
-
+	
 	return nil
 }
 

--- a/dome9/resource_dome9_continuous_compliance_notification.go
+++ b/dome9/resource_dome9_continuous_compliance_notification.go
@@ -1,0 +1,711 @@
+package dome9
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/dome9/dome9-sdk-go/dome9/client"
+	"github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_notification"
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/providerconst"
+)
+
+func resourceContinuousComplianceNotification() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceContinuousComplianceNotificationCreate,
+		Read:   resourceContinuousComplianceNotificationRead,
+		Update: resourceContinuousComplianceNotificationUpdate,
+		Delete: resourceContinuousComplianceNotificationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"alerts_console": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"scheduled_report": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email_sending_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"schedule_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cron_expression": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"Detailed", "Summary", "FullCsv", "FullCsvZip"}, true),
+									},
+									"recipients": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"change_detection": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email_sending_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"email_per_finding_sending_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"sns_sending_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"external_ticket_creating_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"aws_security_hub_integration_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"webhook_integration_state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"email_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"recipients": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+						"email_per_finding_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"recipients": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"notification_output_format": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "JsonWithFullEntity",
+										ValidateFunc: validation.StringInSlice([]string{"JsonWithFullEntity", "JsonWithBasicEntity", "PlainText"}, true),
+									},
+								},
+							},
+						},
+						"sns_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"sns_topic_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"sns_output_format": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"JsonWithFullEntity", "JsonWithBasicEntity", "PlainText"}, true),
+									},
+								},
+							},
+						},
+						"ticketing_system_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"system_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "PagerDuty",
+									},
+									"should_close_tickets": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"domain": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"user": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"pass": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"project_key": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"issue_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"aws_security_hub_integration": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"external_account_id": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"region": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(providerconst.AWSRegions, true),
+									},
+								},
+							},
+						},
+						"webhook_data": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"url": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"http_method": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "Post",
+										ForceNew: true,
+									},
+									"auth_method": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "NoAuth",
+										ValidateFunc: validation.StringInSlice([]string{"NoAuth", "BasicAuth"}, true),
+									},
+									"username": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"password": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"format_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "JsonWithFullEntity",
+										ValidateFunc: validation.StringInSlice([]string{"JsonWithFullEntity", "SplunkBasic", "ServiceNow"}, true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"gcp_security_command_center_integration": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"state": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Disabled",
+							ValidateFunc: validation.StringInSlice([]string{"Disabled", "Enabled"}, true),
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"source_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceContinuousComplianceNotificationCreate(d *schema.ResourceData, meta interface{}) error {
+	d9Client := meta.(*Client)
+	req := expandContinuousComplianceNotificationRequest(d)
+	log.Printf("[INFO] Creating continuous compliance notification request\n%+v\n", req)
+	resp, _, err := d9Client.continuousComplianceNotification.Create(&req)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Created continuous compliance notification request. ID: %v\n", resp.ID)
+	d.SetId(resp.ID)
+
+	return resourceContinuousComplianceNotificationRead(d, meta)
+}
+
+func resourceContinuousComplianceNotificationRead(d *schema.ResourceData, meta interface{}) error {
+	d9Client := meta.(*Client)
+	resp, _, err := d9Client.continuousComplianceNotification.Get(d.Id())
+	if err != nil {
+		if err.(*client.ErrorResponse).IsObjectNotFound() {
+			log.Printf("[WARN] Removing continuous compliance notification %s from state because it no longer exists in Dome9", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	log.Printf("[INFO] Getting continuous compliance notification:\n%+v\n", resp)
+	d.SetId(resp.ID)
+	_ = d.Set("name", resp.Name)
+	_ = d.Set("description", resp.Description)
+	_ = d.Set("alerts_console", resp.AlertsConsole)
+
+	if resp.ScheduledReport != nil {
+		if err := d.Set("scheduled_report", flattenScheduledReport(resp.ScheduledReport)); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("change_detection", flattenChangeDetection(&resp.ChangeDetection)); err != nil {
+		return err
+	}
+
+	if resp.GCPSecurityCommandCenterIntegration != nil {
+		if err = d.Set("gcp_security_command_center_integration", flattenGCPSecurityCommandCenterIntegration(resp.GCPSecurityCommandCenterIntegration)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceContinuousComplianceNotificationDelete(d *schema.ResourceData, meta interface{}) error {
+	d9Client := meta.(*Client)
+	log.Printf("[INFO] Deleting continuous compliance notification ID: %v", d.Id())
+
+	if _, err := d9Client.continuousComplianceNotification.Delete(d.Id()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceContinuousComplianceNotificationUpdate(d *schema.ResourceData, meta interface{}) error {
+	d9Client := meta.(*Client)
+	log.Printf("[INFO] Updating continuous compliance notification ID: %v\n", d.Id())
+	req := expandContinuousComplianceNotificationRequest(d)
+
+	if _, _, err := d9Client.continuousComplianceNotification.Update(d.Id(), &req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandContinuousComplianceNotificationRequest(d *schema.ResourceData) continuous_compliance_notification.ContinuousComplianceNotificationRequest {
+	return continuous_compliance_notification.ContinuousComplianceNotificationRequest{
+		Name:                                d.Get("name").(string),
+		Description:                         d.Get("description").(string),
+		AlertsConsole:                       d.Get("alerts_console").(bool),
+		ScheduledReport:                     expandScheduledReport(d),
+		ChangeDetection:                     *expandChangeDetection(d),
+		GCPSecurityCommandCenterIntegration: expandGCPSecurityCommandCenterIntegration(d),
+	}
+}
+
+func expandScheduledReport(d *schema.ResourceData) *continuous_compliance_notification.ScheduledReport {
+	if scheduledReports, ok := d.GetOk("scheduled_report"); ok {
+		scheduledReportItem := scheduledReports.(*schema.Set).List()[0]
+		scheduledReport := scheduledReportItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.ScheduledReport{
+			EmailSendingState: scheduledReport["email_sending_state"].(string),
+			ScheduleData:      expandScheduleData(scheduledReport["schedule_data"].(*schema.Set)),
+		}
+	}
+
+	return nil
+}
+
+func expandScheduleData(scheduleData *schema.Set) *continuous_compliance_notification.ScheduleData {
+	scheduledDataLst := scheduleData.List()
+	if len(scheduledDataLst) > 0 {
+		scheduledDataItem := scheduledDataLst[0]
+		scheduledData := scheduledDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.ScheduleData{
+			CronExpression: scheduledData["cron_expression"].(string),
+			Type:           scheduledData["type"].(string),
+			Recipients:     expandRecipients(scheduledData["recipients"].([]interface{})),
+		}
+	}
+
+	return nil
+}
+
+func expandChangeDetection(d *schema.ResourceData) *continuous_compliance_notification.ChangeDetection {
+	changeDetectionItem := d.Get("change_detection").(*schema.Set).List()[0]
+	changeDetection := changeDetectionItem.(map[string]interface{})
+
+	return &continuous_compliance_notification.ChangeDetection{
+		EmailSendingState:              changeDetection["email_sending_state"].(string),
+		EmailPerFindingSendingState:    changeDetection["email_per_finding_sending_state"].(string),
+		SNSSendingState:                changeDetection["sns_sending_state"].(string),
+		ExternalTicketCreatingState:    changeDetection["external_ticket_creating_state"].(string),
+		AWSSecurityHubIntegrationState: changeDetection["aws_security_hub_integration_state"].(string),
+		WebhookIntegrationState:        changeDetection["webhook_integration_state"].(string),
+		EmailData:                      expandEmailData(changeDetection["email_data"].(*schema.Set)),
+		EmailPerFindingData:            expandEmailPerFindingData(changeDetection["email_per_finding_data"].(*schema.Set)),
+		SNSData:                        expandSNSData(changeDetection["sns_data"].(*schema.Set)),
+		TicketingSystemData:            expandTicketingSystemData(changeDetection["ticketing_system_data"].(*schema.Set)),
+		AWSSecurityHubIntegration:      expandAWSSecurityHubIntegration(changeDetection["aws_security_hub_integration"].(*schema.Set)),
+		WebhookData:                    expandWebhookData(changeDetection["webhook_data"].(*schema.Set)),
+	}
+}
+
+func expandEmailData(emailData *schema.Set) *continuous_compliance_notification.EmailData {
+	emailDataLst := emailData.List()
+	if len(emailDataLst) > 0 {
+		emailDataItem := emailDataLst[0]
+		emailData := emailDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.EmailData{
+			Recipients: expandRecipients(emailData["recipients"].([]interface{})),
+		}
+	}
+
+	return nil
+}
+
+func expandEmailPerFindingData(emailPerFindingData *schema.Set) *continuous_compliance_notification.EmailPerFindingData {
+	emailPerFindingDataLst := emailPerFindingData.List()
+	if len(emailPerFindingDataLst) > 0 {
+		emailPerFindingDataItem := emailPerFindingDataLst[0]
+		emailPerFindingData := emailPerFindingDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.EmailPerFindingData{
+			Recipients:               expandRecipients(emailPerFindingData["recipients"].([]interface{})),
+			NotificationOutputFormat: emailPerFindingData["notification_output_format"].(string),
+		}
+	}
+
+	return nil
+}
+
+func expandSNSData(snsData *schema.Set) *continuous_compliance_notification.SNSData {
+	snsDataLst := snsData.List()
+	if len(snsDataLst) > 0 {
+		snsDataItem := snsDataLst[0]
+		snsData := snsDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.SNSData{
+			SNSTopicArn:     snsData["sns_topic_arn"].(string),
+			SNSOutputFormat: snsData["sns_output_format"].(string),
+		}
+	}
+
+	return nil
+}
+
+func expandTicketingSystemData(ticketingSystemData *schema.Set) *continuous_compliance_notification.TicketingSystemData {
+	ticketingSystemDataLst := ticketingSystemData.List()
+	if len(ticketingSystemDataLst) > 0 {
+		ticketingSystemDataItem := ticketingSystemDataLst[0]
+		ticketingSystemData := ticketingSystemDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.TicketingSystemData{
+			SystemType:         ticketingSystemData["system_type"].(string),
+			ShouldCloseTickets: ticketingSystemData["should_close_tickets"].(bool),
+			Domain:             ticketingSystemData["domain"].(string),
+			User:               ticketingSystemData["user"].(string),
+			Pass:               ticketingSystemData["pass"].(string),
+			ProjectKey:         ticketingSystemData["project_key"].(string),
+			IssueType:          ticketingSystemData["issue_type"].(string),
+		}
+	}
+
+	return nil
+}
+
+func expandAWSSecurityHubIntegration(awsSecurityHubIntegration *schema.Set) *continuous_compliance_notification.AWSSecurityHubIntegration {
+	awsSecurityHubIntegrationLst := awsSecurityHubIntegration.List()
+	if len(awsSecurityHubIntegrationLst) > 0 {
+		awsSecurityHubIntegrationItem := awsSecurityHubIntegrationLst[0]
+		awsSecurityHubIntegration := awsSecurityHubIntegrationItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.AWSSecurityHubIntegration{
+			ExternalAccountID: awsSecurityHubIntegration["external_account_id"].(string),
+			Region:            awsSecurityHubIntegration["region"].(string),
+		}
+	}
+
+	return nil
+}
+
+func expandWebhookData(webhookData *schema.Set) *continuous_compliance_notification.WebhookData {
+	webhookDataLst := webhookData.List()
+	if len(webhookDataLst) > 0 {
+		webhookDataItem := webhookDataLst[0]
+		webhookData := webhookDataItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.WebhookData{
+			URL:        webhookData["url"].(string),
+			HTTPMethod: webhookData["http_method"].(string),
+			AuthMethod: webhookData["auth_method"].(string),
+			Username:   webhookData["username"].(string),
+			Password:   webhookData["password"].(string),
+			FormatType: webhookData["format_type"].(string),
+		}
+	}
+
+	return nil
+}
+
+func expandRecipients(generalRecipients []interface{}) []string {
+	recipients := make([]string, len(generalRecipients))
+	for i, recipient := range generalRecipients {
+		recipients[i] = recipient.(string)
+	}
+
+	return recipients
+}
+
+func expandGCPSecurityCommandCenterIntegration(d *schema.ResourceData) *continuous_compliance_notification.GCPSecurityCommandCenterIntegration {
+	if gcpSecurityCommandCenterIntegration, ok := d.GetOk("gcp_security_command_center_integration"); ok {
+		gcpSecurityCommandCenterIntegrationItem := gcpSecurityCommandCenterIntegration.(*schema.Set).List()[0]
+		gcpSecurityCommandCenterIntegration := gcpSecurityCommandCenterIntegrationItem.(map[string]interface{})
+
+		return &continuous_compliance_notification.GCPSecurityCommandCenterIntegration{
+			State:     gcpSecurityCommandCenterIntegration["state"].(string),
+			ProjectID: gcpSecurityCommandCenterIntegration["project_id"].(string),
+			SourceID:  gcpSecurityCommandCenterIntegration["source_id"].(string),
+		}
+	}
+
+	return nil
+}
+
+func flattenGCPSecurityCommandCenterIntegration(respGCPSecurityCommandCenterIntegration *continuous_compliance_notification.GCPSecurityCommandCenterIntegration) []interface{} {
+	m := map[string]interface{}{
+		"state":      respGCPSecurityCommandCenterIntegration.State,
+		"project_id": respGCPSecurityCommandCenterIntegration.ProjectID,
+		"source_id":  respGCPSecurityCommandCenterIntegration.SourceID,
+	}
+
+	return []interface{}{m}
+}
+
+func flattenScheduledReport(respScheduledReport *continuous_compliance_notification.ScheduledReport) []interface{} {
+	m := map[string]interface{}{
+		"email_sending_state": respScheduledReport.EmailSendingState,
+		"schedule_data":       flattenScheduleData(respScheduledReport.ScheduleData),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenScheduleData(respScheduleData *continuous_compliance_notification.ScheduleData) []interface{} {
+	if respScheduleData == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"cron_expression": respScheduleData.CronExpression,
+		"type":            respScheduleData.Type,
+		"recipients":      flattenRecipients(respScheduleData.Recipients),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenRecipients(generalRecipients []string) []string {
+	recipients := make([]string, len(generalRecipients))
+	for i, val := range generalRecipients {
+		recipients[i] = val
+	}
+
+	return recipients
+}
+
+func flattenChangeDetection(respChangeDetection *continuous_compliance_notification.ChangeDetection) []interface{} {
+	m := map[string]interface{}{
+		"email_sending_state":                respChangeDetection.EmailSendingState,
+		"email_per_finding_sending_state":    respChangeDetection.EmailPerFindingSendingState,
+		"sns_sending_state":                  respChangeDetection.SNSSendingState,
+		"external_ticket_creating_state":     respChangeDetection.ExternalTicketCreatingState,
+		"aws_security_hub_integration_state": respChangeDetection.AWSSecurityHubIntegrationState,
+		"webhook_integration_state":          respChangeDetection.WebhookIntegrationState,
+	}
+
+	if respChangeDetection.EmailData != nil {
+		m["email_data"] = flattenEmailData(respChangeDetection.EmailData)
+	}
+
+	if respChangeDetection.EmailPerFindingData != nil {
+		m["email_per_finding_data"] = flattenEmailPerFindingData(respChangeDetection.EmailPerFindingData)
+	}
+
+	if respChangeDetection.SNSData != nil {
+		m["sns_data"] = flattenSnsData(respChangeDetection.SNSData)
+	}
+
+	if respChangeDetection.TicketingSystemData != nil {
+		m["ticketing_system_data"] = flattenTicketingSystemData(respChangeDetection.TicketingSystemData)
+	}
+
+	if respChangeDetection.AWSSecurityHubIntegration != nil {
+		m["aws_security_hub_integration"] = flattenAWSSecurityHubIntegration(respChangeDetection.AWSSecurityHubIntegration)
+	}
+
+	if respChangeDetection.WebhookData != nil {
+		m["webhook_data"] = flattenWebhookData(respChangeDetection.WebhookData)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenAWSSecurityHubIntegration(respAWSSecurityHubIntegration *continuous_compliance_notification.AWSSecurityHubIntegration) []interface{} {
+	m := map[string]interface{}{
+		"external_account_id": respAWSSecurityHubIntegration.ExternalAccountID,
+		"region":              respAWSSecurityHubIntegration.Region,
+	}
+
+	return []interface{}{m}
+}
+
+func flattenWebhookData(respWebhookData *continuous_compliance_notification.WebhookData) []interface{} {
+	m := map[string]interface{}{
+		"url":         respWebhookData.URL,
+		"http_method": respWebhookData.HTTPMethod,
+		"auth_method": respWebhookData.AuthMethod,
+		"username":    respWebhookData.Username,
+		"password":    respWebhookData.Password,
+		"format_type": respWebhookData.FormatType,
+	}
+
+	return []interface{}{m}
+}
+
+func flattenTicketingSystemData(respTicketingSystemData *continuous_compliance_notification.TicketingSystemData) []interface{} {
+	m := map[string]interface{}{
+		"system_type":          respTicketingSystemData.SystemType,
+		"should_close_tickets": respTicketingSystemData.ShouldCloseTickets,
+		"domain":               respTicketingSystemData.Domain,
+		"user":                 respTicketingSystemData.User,
+		"pass":                 respTicketingSystemData.Pass,
+		"project_key":          respTicketingSystemData.ProjectKey,
+		"issue_type":           respTicketingSystemData.IssueType,
+	}
+
+	return []interface{}{m}
+}
+
+func flattenSnsData(respSNSData *continuous_compliance_notification.SNSData) []interface{} {
+	m := map[string]interface{}{
+		"sns_topic_arn":     respSNSData.SNSTopicArn,
+		"sns_output_format": respSNSData.SNSOutputFormat,
+	}
+
+	return []interface{}{m}
+}
+
+func flattenEmailData(respEmailData *continuous_compliance_notification.EmailData) []interface{} {
+	m := map[string]interface{}{
+		"recipients": flattenRecipients(respEmailData.Recipients),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenEmailPerFindingData(respEmailPerFindingData *continuous_compliance_notification.EmailPerFindingData) []interface{} {
+	m := map[string]interface{}{
+		"recipients":                 flattenRecipients(respEmailPerFindingData.Recipients),
+		"notification_output_format": respEmailPerFindingData.NotificationOutputFormat,
+	}
+
+	return []interface{}{m}
+}

--- a/dome9/resource_dome9_continuous_compliance_notification.go
+++ b/dome9/resource_dome9_continuous_compliance_notification.go
@@ -370,7 +370,7 @@ func resourceContinuousComplianceNotificationDelete(d *schema.ResourceData, meta
 	if _, err := d9Client.continuousComplianceNotification.Delete(d.Id()); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/dome9/resource_dome9_continuous_compliance_notification_test.go
+++ b/dome9/resource_dome9_continuous_compliance_notification_test.go
@@ -1,0 +1,189 @@
+package dome9
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_notification"
+
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/resourcetype"
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/method"
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/testing/variable"
+)
+
+func TestAccResourceContinuousComplianceNotificationBasic(t *testing.T) {
+	var continuousComplianceNotificationResponse continuous_compliance_notification.ContinuousComplianceNotificationResponse
+	resourceTypeAndName, _, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContinuousComplianceNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, continuousComplianceNotificationConfig()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousComplianceNotificationExists(resourceTypeAndName, &continuousComplianceNotificationResponse),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "name", variable.ContinuousComplianceNotificationName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "description", variable.ContinuousComplianceNotificationDescription),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationAlertsConsole)),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "scheduled_report.#", "1"),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "change_detection.#", "1"),
+				),
+			},
+			{
+				// update name test
+				Config: testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, continuousComplianceNotificationUpdateConfig()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousComplianceNotificationExists(resourceTypeAndName, &continuousComplianceNotificationResponse),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "name", variable.ContinuousComplianceNotificationUpdateName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "description", variable.ContinuousComplianceNotificationUpdateDescription),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationUpdateAlertsConsole)),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "scheduled_report.#", "0"),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "change_detection.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckContinuousComplianceNotificationExists(resource string, continuousComplianceNotification *continuous_compliance_notification.ContinuousComplianceNotificationResponse) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("didn't find resource: %s", resource)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no record ID is set")
+		}
+
+		apiClient := testAccProvider.Meta().(*Client)
+		receivedContinuousComplianceNotificationResponse, _, err := apiClient.continuousComplianceNotification.Get(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("failed fetching resource %s. Recevied error: %s", resource, err)
+		}
+		*continuousComplianceNotification = *receivedContinuousComplianceNotificationResponse
+
+		return nil
+	}
+}
+
+func testAccCheckContinuousComplianceNotificationDestroy(s *terraform.State) error {
+	apiClient := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != resourcetype.ContinuousComplianceNotification {
+			continue
+		}
+
+		receivedContinuousComplianceNotificationResponse, _, err := apiClient.continuousComplianceNotification.Get(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("id %s already exists", rs.Primary.ID)
+		}
+
+		if receivedContinuousComplianceNotificationResponse != nil {
+			return fmt.Errorf("notification with id %s exists and wasn't destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, additionalBlock string) string {
+	return fmt.Sprintf(`
+// continuous compliance notification creation
+resource "%s" "%s" {
+  %s
+  change_detection {
+    email_sending_state                = "%s"
+    email_per_finding_sending_state    = "%s"
+    sns_sending_state                  = "%s"
+    external_ticket_creating_state     = "%s"
+    aws_security_hub_integration_state = "%s"
+    webhook_integration_state          = "%s"
+
+    email_data {
+      recipients = ["%s"]
+    }
+
+    email_per_finding_data {
+      recipients                 = ["%s"]
+      notification_output_format = "%s"
+    }
+  }
+}
+
+data "%s" "%s" {
+  id = "${%s.id}"
+}
+`,
+		// resource variables
+		resourcetype.ContinuousComplianceNotification,
+		generatedName,
+
+		additionalBlock,
+
+		variable.ContinuousComplianceNotificationEnabled,
+		variable.ContinuousComplianceNotificationEnabled,
+		variable.ContinuousComplianceNotificationDisabled,
+		variable.ContinuousComplianceNotificationDisabled,
+		variable.ContinuousComplianceNotificationDisabled,
+		variable.ContinuousComplianceNotificationDisabled,
+
+		variable.ContinuousComplianceNotificationRecipient,
+
+		variable.ContinuousComplianceNotificationRecipient,
+		variable.ContinuousComplianceNotificationJsonWithFullEntity,
+
+		// data source variables
+		resourcetype.ContinuousComplianceNotification,
+		generatedName,
+		resourceTypeAndName,
+	)
+}
+
+func continuousComplianceNotificationConfig() string {
+	return fmt.Sprintf(`
+name           = "%s"
+description    = "%s"
+alerts_console = "%s"
+
+scheduled_report {
+  email_sending_state = "%s"
+  schedule_data {
+    cron_expression = "%s"
+    type            = "%s"
+    recipients      = ["%s"]
+  }
+}
+`,
+		variable.ContinuousComplianceNotificationName,
+		variable.ContinuousComplianceNotificationDescription,
+		strconv.FormatBool(variable.ContinuousComplianceNotificationAlertsConsole),
+
+		variable.ContinuousComplianceNotificationEnabled,
+		variable.ContinuousComplianceNotificationCronExpression,
+		variable.ContinuousComplianceNotificationType,
+		variable.ContinuousComplianceNotificationRecipient,
+	)
+}
+
+func continuousComplianceNotificationUpdateConfig() string {
+	return fmt.Sprintf(`
+name           = "%s"
+description    = "%s"
+alerts_console = "%s"
+`,
+		variable.ContinuousComplianceNotificationUpdateName,
+		variable.ContinuousComplianceNotificationUpdateDescription,
+		strconv.FormatBool(variable.ContinuousComplianceNotificationUpdateAlertsConsole),
+	)
+}

--- a/dome9/resource_dome9_continuous_compliance_notification_test.go
+++ b/dome9/resource_dome9_continuous_compliance_notification_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccResourceContinuousComplianceNotificationBasic(t *testing.T) {
 	var continuousComplianceNotificationResponse continuous_compliance_notification.ContinuousComplianceNotificationResponse
-	resourceTypeAndName, _, generatedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
+	notificationTypeAndName, _, notificationGeneratedName := method.GenerateRandomSourcesTypeAndName(resourcetype.ContinuousComplianceNotification)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -27,26 +27,26 @@ func TestAccResourceContinuousComplianceNotificationBasic(t *testing.T) {
 		CheckDestroy: testAccCheckContinuousComplianceNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, continuousComplianceNotificationConfig()),
+				Config: testAccCheckContinuousComplianceNotificationBasic(notificationTypeAndName, notificationGeneratedName, continuousComplianceNotificationConfig()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckContinuousComplianceNotificationExists(resourceTypeAndName, &continuousComplianceNotificationResponse),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "name", variable.ContinuousComplianceNotificationName),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "description", variable.ContinuousComplianceNotificationDescription),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationAlertsConsole)),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "scheduled_report.#", "1"),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "change_detection.#", "1"),
+					testAccCheckContinuousComplianceNotificationExists(notificationTypeAndName, &continuousComplianceNotificationResponse),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "name", variable.ContinuousComplianceNotificationName),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "description", variable.ContinuousComplianceNotificationDescription),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationAlertsConsole)),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "scheduled_report.#", "1"),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "change_detection.#", "1"),
 				),
 			},
 			{
 				// update name test
-				Config: testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, continuousComplianceNotificationUpdateConfig()),
+				Config: testAccCheckContinuousComplianceNotificationBasic(notificationTypeAndName, notificationGeneratedName, continuousComplianceNotificationUpdateConfig()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckContinuousComplianceNotificationExists(resourceTypeAndName, &continuousComplianceNotificationResponse),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "name", variable.ContinuousComplianceNotificationUpdateName),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "description", variable.ContinuousComplianceNotificationUpdateDescription),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationUpdateAlertsConsole)),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "scheduled_report.#", "0"),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "change_detection.#", "1"),
+					testAccCheckContinuousComplianceNotificationExists(notificationTypeAndName, &continuousComplianceNotificationResponse),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "name", variable.ContinuousComplianceNotificationUpdateName),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "description", variable.ContinuousComplianceNotificationUpdateDescription),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "alerts_console", strconv.FormatBool(variable.ContinuousComplianceNotificationUpdateAlertsConsole)),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "scheduled_report.#", "0"),
+					resource.TestCheckResourceAttr(notificationTypeAndName, "change_detection.#", "1"),
 				),
 			},
 		},
@@ -99,6 +99,25 @@ func testAccCheckContinuousComplianceNotificationDestroy(s *terraform.State) err
 
 func testAccCheckContinuousComplianceNotificationBasic(resourceTypeAndName, generatedName, additionalBlock string) string {
 	return fmt.Sprintf(`
+// continuous compliance notification resource
+%s
+
+data "%s" "%s" {
+  id = "${%s.id}"
+}
+`,
+		// continuous compliance notification resource
+		getContinuousComplianceNotificationResourceHCL(generatedName, additionalBlock),
+
+		// data source variables
+		resourcetype.ContinuousComplianceNotification,
+		generatedName,
+		resourceTypeAndName,
+	)
+}
+
+func getContinuousComplianceNotificationResourceHCL(generatedName, additionalBlock string) string {
+	return fmt.Sprintf(`
 // continuous compliance notification creation
 resource "%s" "%s" {
   %s
@@ -120,10 +139,6 @@ resource "%s" "%s" {
     }
   }
 }
-
-data "%s" "%s" {
-  id = "${%s.id}"
-}
 `,
 		// resource variables
 		resourcetype.ContinuousComplianceNotification,
@@ -142,14 +157,8 @@ data "%s" "%s" {
 
 		variable.ContinuousComplianceNotificationRecipient,
 		variable.ContinuousComplianceNotificationJsonWithFullEntity,
-
-		// data source variables
-		resourcetype.ContinuousComplianceNotification,
-		generatedName,
-		resourceTypeAndName,
 	)
 }
-
 func continuousComplianceNotificationConfig() string {
 	return fmt.Sprintf(`
 name           = "%s"

--- a/dome9/resource_dome9_continuous_compliance_policy.go
+++ b/dome9/resource_dome9_continuous_compliance_policy.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/dome9/dome9-sdk-go/dome9/client"
 	"github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_policy"
@@ -30,8 +31,9 @@ func resourceContinuousCompliancePolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"cloud_account_type": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Azure", "Aws", "Google", "Kubernetes"}, false),
 			},
 			"bundle_id": {
 				Type:     schema.TypeInt,

--- a/dome9/resource_dome9_continuous_compliance_policy.go
+++ b/dome9/resource_dome9_continuous_compliance_policy.go
@@ -42,7 +42,8 @@ func resourceContinuousCompliancePolicy() *schema.Resource {
 			"notification_ids": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				// ForceNew: true,
+				Elem: &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -109,7 +110,6 @@ func resourceContinuousCompliancePolicyDelete(d *schema.ResourceData, meta inter
 	if _, err := d9Client.continuousCompliancePolicy.Delete(d.Id()); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/dome9/resource_dome9_iplist_test.go
+++ b/dome9/resource_dome9_iplist_test.go
@@ -119,13 +119,13 @@ data "%s" "%s" {
   id = "${%s.id}"
 }
 `,
-		// resource variable
+		// resource variables
 		resourcetype.IPList,
 		generatedName,
 		variable.IPListCreationResourceName,
 		description,
 
-		// data source variable
+		// data source variables
 		resourcetype.IPList,
 		generatedName,
 		resourceTypeAndName,

--- a/examples/continuous_compliance/policy/main.tf
+++ b/examples/continuous_compliance/policy/main.tf
@@ -3,7 +3,7 @@ provider "dome9" {
   dome9_secret_key = "--"
 }
 
-resource "dome9_continuouscompliance_policy" "test_policy" {
+resource "dome9_continuous_compliance_policy" "test_policy" {
   cloud_account_id    = "CLOUD_ACCOUNT_ID"
   external_account_id = "EXTERNAL_ACCOUNT_ID"
   bundle_id           = 00000

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-providers/terraform-provider-dome9
 go 1.13
 
 require (
-	github.com/dome9/dome9-sdk-go v1.2.2
+	github.com/dome9/dome9-sdk-go v1.2.3
 	github.com/hashicorp/terraform v0.12.10
 )

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/dome9/dome9-sdk-go v1.2.2 h1:6Bzj7isg28XYKHOc2UpCUFpvvHQvybxalOQlO5HSQUE=
-github.com/dome9/dome9-sdk-go v1.2.2/go.mod h1:CF7nXCQk74ApsoG2i1+ziC/pnnnsyMeG6Mpho8cRAGM=
+github.com/dome9/dome9-sdk-go v1.2.3 h1:7LyQpKnuJZv7BoIbRnz0z4MGqZSkDPhTYWRgsWfFDWo=
+github.com/dome9/dome9-sdk-go v1.2.3/go.mod h1:CF7nXCQk74ApsoG2i1+ziC/pnnnsyMeG6Mpho8cRAGM=
 github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCfx+QkYnoQ=
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,13 +61,14 @@ github.com/blang/semver
 github.com/bmatcuk/doublestar
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/dome9/dome9-sdk-go v1.2.2
+# github.com/dome9/dome9-sdk-go v1.2.3
 github.com/dome9/dome9-sdk-go/dome9
 github.com/dome9/dome9-sdk-go/dome9/client
 github.com/dome9/dome9-sdk-go/services/cloudaccounts
 github.com/dome9/dome9-sdk-go/services/cloudaccounts/aws
 github.com/dome9/dome9-sdk-go/services/cloudaccounts/azure
 github.com/dome9/dome9-sdk-go/services/cloudaccounts/gcp
+github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_notification
 github.com/dome9/dome9-sdk-go/services/compliance/continuous_compliance_policy
 github.com/dome9/dome9-sdk-go/services/iplist
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
## Continuous compliance notification resource
- Resource continuous compliance notification
- Changing the name of client to d9Client
- In cases that object is not found (404), empty ID is set
- Data source continuous compliance notification 
- Update continuous compliance notification
- Test resource cc policy creating cc notification
- Test resource continuous compliance policy creating continuous compliance notification and using her ID rather than using const ID that has been passed as environment variable.
- Adding validation for resource continuous compliance policy
- Replacing account_id to id in the resources azure and gcp cloud accounts
- CC Policy go fmt fix
- Test update continuous compliance policy
- Bumped SDK version (v1.2.3)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-dome9/blob/master/CHANGELOG.md):
***
Output from acceptance tests:
```
=== RUN   TestAccDataSourceContinuousComplianceNotificationBasic
--- PASS: TestAccDataSourceContinuousComplianceNotificationBasic (2.18s)
=== RUN   TestAccResourceContinuousComplianceNotificationBasic
--- PASS: TestAccResourceContinuousComplianceNotificationBasic (4.15s)
```