### PR TITLE
Mark secret key as sensitive and don't print it

### DIFF
--- a/dome9/config.go
+++ b/dome9/config.go
@@ -33,9 +33,7 @@ type Config struct {
 }
 
 func (c *Config) Client() (*Client, error) {
-
 	config, err := dome9.NewConfig(c.AccessID, c.SecretKey, c.BaseURL)
-
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +47,6 @@ func (c *Config) Client() (*Client, error) {
 		continuousComplianceNotification: *continuous_compliance_notification.New(config),
 	}
 
-	log.Println("initialized client")
+	log.Println("[INFO] initialized Dome9 client")
 	return client, nil
 }

--- a/dome9/provider.go
+++ b/dome9/provider.go
@@ -1,8 +1,6 @@
 package dome9
 
 import (
-	"log"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -22,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 			providerconst.ProviderSecretKey: {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc(providerconst.ProviderSecretKeyEnvVariable, nil),
 				Description: "dome9 api secret",
 			},
@@ -64,6 +63,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		BaseURL:   d.Get(providerconst.ProviderBaseURL).(string),
 	}
 
-	log.Println("initializing dome9 client with config:", config)
 	return config.Client()
 }


### PR DESCRIPTION
- Mark secret API key as sensitive
- Remove logging API secret key

Solves #17 

Tests remain unaffected:
```
=== RUN   TestAccDataSourceCloudAccountAWSBasic
--- PASS: TestAccDataSourceCloudAccountAWSBasic (4.04s)
=== RUN   TestAccDataSourceCloudAccountAzureBasic
--- PASS: TestAccDataSourceCloudAccountAzureBasic (3.38s)
=== RUN   TestAccDataSourceCloudAccountGCPBasic
--- PASS: TestAccDataSourceCloudAccountGCPBasic (3.38s)
=== RUN   TestAccDataSourceContinuousComplianceNotificationBasic
--- PASS: TestAccDataSourceContinuousComplianceNotificationBasic (1.98s)
=== RUN   TestAccDataSourceContinuousCompliancePolicyBasic
--- PASS: TestAccDataSourceContinuousCompliancePolicyBasic (4.51s)
=== RUN   TestAccDataSourceIpListBasic
--- PASS: TestAccDataSourceIpListBasic (2.30s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccResourceCloudAccountAWSBasic
--- PASS: TestAccResourceCloudAccountAWSBasic (6.60s)
=== RUN   TestAccResourceCloudAccountAzureBasic
--- PASS: TestAccResourceCloudAccountAzureBasic (4.40s)
=== RUN   TestAccResourceCloudAccountGCPBasic
--- PASS: TestAccResourceCloudAccountGCPBasic (4.38s)
=== RUN   TestAccResourceContinuousComplianceNotificationBasic
--- PASS: TestAccResourceContinuousComplianceNotificationBasic (3.44s)
=== RUN   TestAccResourceContinuousCompliancePolicyBasic
--- PASS: TestAccResourceContinuousCompliancePolicyBasic (6.73s)
=== RUN   TestAccResourceIPListBasic
--- PASS: TestAccResourceIPListBasic (3.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-dome9/dome9	49.055s
```