### PR TITLE
Fix make lint - exclude vendor and increase timeout

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./...
+	golangci-lint run  --timeout=5m ./$(PKG_NAME)/...
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
- `golangci-lint run ./...` ran on all go files including the files in `vendor` thus resulting in a timeout. Now it will run only on the go files in `dome9` directory.
- Increase timeout to 5 minutes.

Resolves #19 
