### PR TITLE
Add tflint process to Travis-CI and set go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,37 @@
-dist: trusty
+dist: xenial
 sudo: required
 services:
-- docker
+  - docker
 language: go
 go:
-  - "1.11.x"
+  - "1.13.x"
+env:
+  global: GOFLAGS=-mod=vendor
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+  include:
+    - name: "Code lint"
+      script: make lint
+    - name: "Code tflint"
+      script: make tflint
+    - name: "Code UnitTest"
+      script: make test
+    - name: "Website"
+      script:
+        - make website-test
+        - make website-lint
+
+install:
+  # This script is used by the Travis build to install a cookie for
+  # go.googlesource.com so rate limits are higher when using `go get` to fetch
+  # packages that live there.
+  # See: https://github.com/golang/go/issues/12933
+  - bash scripts/gogetcookie.sh
+  - make tools
 
 branches:
   only:
   - master
-
-install:
-# This script is used by the Travis build to install a cookie for
-# go.googlesource.com so rate limits are higher when using `go get` to fetch
-# packages that live there.
-# See: https://github.com/golang/go/issues/12933
-- bash scripts/gogetcookie.sh
-- make tools 
-  
-matrix:
-  fast_finish: true
-  allow_failures:
-  - go: tip
-  include:
-  - name: "make lint"
-    script: make lint
-  - name: "make test"
-    script: make test
-  - name: "make website-lint"
-    script: make website-lint
-  - name: "make website-test"
-    script: make website-test
-env:
-  - GOFLAGS=-mod=vendor GO111MODULE=on

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,12 +6,15 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 
 default: build
 
-tools:
-	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
-	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-
 build: fmtcheck
 	go install
+
+tools:
+	@echo "==> installing required tooling..."
+	@sh "$(CURDIR)/scripts/gogetcookie.sh"
+	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
+	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	GO111MODULE=off go get -u github.com/bflad/tfproviderlint/cmd/tfproviderlint
 
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
@@ -26,6 +29,31 @@ fmtcheck:
 lint:
 	@echo "==> Checking source code against linters..."
 	golangci-lint run  --timeout=5m ./$(PKG_NAME)/...
+
+tflint:
+	@echo "==> Checking source code against terraform provider linters..."
+	@tfproviderlint \
+		-c 1 \
+		-AT001 \
+		-AT002 \
+		-S001 \
+		-S002 \
+		-S003 \
+		-S004 \
+		-S005 \
+		-S007 \
+		-S008 \
+		-S009 \
+		-S010 \
+		-S011 \
+		-S012 \
+		-S013 \
+		-S014 \
+		-S015 \
+		-S016 \
+		-S017 \
+		-S019 \
+		./$(PKG_NAME)
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
- Add tflint process to Travis-CI.
- Use go 1.13.x in Travic-CI.

Tests remains unaffected:
```
=== RUN   TestAccDataSourceCloudAccountAWSBasic
--- PASS: TestAccDataSourceCloudAccountAWSBasic (4.64s)
=== RUN   TestAccDataSourceCloudAccountAzureBasic
--- PASS: TestAccDataSourceCloudAccountAzureBasic (3.54s)
=== RUN   TestAccDataSourceCloudAccountGCPBasic
--- PASS: TestAccDataSourceCloudAccountGCPBasic (3.03s)
=== RUN   TestAccDataSourceContinuousComplianceNotificationBasic
--- PASS: TestAccDataSourceContinuousComplianceNotificationBasic (1.77s)
=== RUN   TestAccDataSourceContinuousCompliancePolicyBasic
--- PASS: TestAccDataSourceContinuousCompliancePolicyBasic (4.45s)
=== RUN   TestAccDataSourceIpListBasic
--- PASS: TestAccDataSourceIpListBasic (2.24s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccResourceCloudAccountAWSBasic
--- PASS: TestAccResourceCloudAccountAWSBasic (6.78s)
=== RUN   TestAccResourceCloudAccountAzureBasic
--- PASS: TestAccResourceCloudAccountAzureBasic (4.59s)
=== RUN   TestAccResourceCloudAccountGCPBasic
--- PASS: TestAccResourceCloudAccountGCPBasic (5.07s)
=== RUN   TestAccResourceContinuousComplianceNotificationBasic
--- PASS: TestAccResourceContinuousComplianceNotificationBasic (3.83s)
=== RUN   TestAccResourceContinuousCompliancePolicyBasic
--- PASS: TestAccResourceContinuousCompliancePolicyBasic (7.22s)
=== RUN   TestAccResourceIPListBasic
--- PASS: TestAccResourceIPListBasic (4.15s)
PASS
```