### PR TITLE
Attach cloudaccount to OU on create

### DIFF
--- a/dome9/data_source_dome9_cloudaccount_aws.go
+++ b/dome9/data_source_dome9_cloudaccount_aws.go
@@ -46,6 +46,10 @@ func dataSourceCloudAccountAWS() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"organizational_unit_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"net_sec": {
 				Type:     schema.TypeSet,
 				MaxItems: 1,
@@ -103,6 +107,7 @@ func dataSourceAWSRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("creation_date", resp.CreationDate.Format("2006-01-02 15:04:05"))
 	_ = d.Set("full_protection", resp.FullProtection)
 	_ = d.Set("allow_read_only", resp.AllowReadOnly)
+	_ = d.Set("organizational_unit_id", resp.OrganizationalUnitID)
 	if err := d.Set("net_sec", flattenCloudAccountAWSNetSec(resp.NetSec)); err != nil {
 		return err
 	}

--- a/dome9/resource_dome9_cloudaccount_gcp.go
+++ b/dome9/resource_dome9_cloudaccount_gcp.go
@@ -220,6 +220,7 @@ func expandCloudAccountGCPRequest(d *schema.ResourceData) gcp.CloudAccountReques
 		ServiceAccountCredentials: expandServiceAccountCredentials(d),
 		GsuiteUser:                d.Get("gsuite_user").(string),
 		DomainName:                d.Get("domain_name").(string),
+		OrganizationalUnitID:      d.Get("organizational_unit_id").(string),
 	}
 
 	return req

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-providers/terraform-provider-dome9
 go 1.13
 
 require (
-	github.com/dome9/dome9-sdk-go v1.3.0
+	github.com/dome9/dome9-sdk-go v1.3.1
 	github.com/hashicorp/terraform v0.12.10
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQ
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dome9/dome9-sdk-go v1.3.0 h1:vUPvUVVVeuSk9TWMbrV0zlnZOAOIivuOOop71wmHLqY=
 github.com/dome9/dome9-sdk-go v1.3.0/go.mod h1:CF7nXCQk74ApsoG2i1+ziC/pnnnsyMeG6Mpho8cRAGM=
+github.com/dome9/dome9-sdk-go v1.3.1 h1:1Iv+g5QxXfXX1k31n7+hGUGiH1z5Vp+sRuCLzP7WPcE=
+github.com/dome9/dome9-sdk-go v1.3.1/go.mod h1:CF7nXCQk74ApsoG2i1+ziC/pnnnsyMeG6Mpho8cRAGM=
 github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCfx+QkYnoQ=
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/github.com/dome9/dome9-sdk-go/services/cloudaccounts/aws/aws.go
+++ b/vendor/github.com/dome9/dome9-sdk-go/services/cloudaccounts/aws/aws.go
@@ -162,7 +162,6 @@ func (service *Service) UpdateRegionConfig(body CloudAccountUpdateRegionConfigRe
 	return v, resp, nil
 }
 
-// TODO: not implemented in TF provider due to bug https://dome9-security.atlassian.net/browse/DOME-12538
 func (service *Service) UpdateOrganizationalID(id string, body CloudAccountUpdateOrganizationalIDRequest) (*CloudAccountResponse, *http.Response, error) {
 	v := new(CloudAccountResponse)
 	relativeURL := fmt.Sprintf("%s/%s/%s", cloudaccounts.RESTfulPathAWS, id, cloudaccounts.RESTfulServicePathAWSOrganizationalUnit)

--- a/vendor/github.com/dome9/dome9-sdk-go/services/cloudaccounts/gcp/gcp.go
+++ b/vendor/github.com/dome9/dome9-sdk-go/services/cloudaccounts/gcp/gcp.go
@@ -14,6 +14,7 @@ type CloudAccountRequest struct {
 	ServiceAccountCredentials ServiceAccountCredentials `json:"serviceAccountCredentials,omitempty"`
 	GsuiteUser                string                    `json:"gsuiteUser,omitempty"`
 	DomainName                string                    `json:"domainName,omitempty"`
+	OrganizationalUnitID      string                    `json:"organizationalUnitId,omitempty"`
 }
 
 type CloudAccountResponse struct {
@@ -21,7 +22,7 @@ type CloudAccountResponse struct {
 	Name                   string    `json:"name"`
 	ProjectID              string    `json:"projectId"`
 	CreationDate           time.Time `json:"creationDate"`
-	OrganizationalUnitID   string    `json:"organizationalUnitId,omitempty"`
+	OrganizationalUnitID   string    `json:"organizationalUnitId"`
 	OrganizationalUnitPath string    `json:"organizationalUnitPath"`
 	OrganizationalUnitName string    `json:"organizationalUnitName"`
 	GSuite                 GSuite    `json:"gSuite,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/blang/semver
 github.com/bmatcuk/doublestar
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/dome9/dome9-sdk-go v1.3.0
+# github.com/dome9/dome9-sdk-go v1.3.1
 github.com/dome9/dome9-sdk-go/dome9
 github.com/dome9/dome9-sdk-go/dome9/client
 github.com/dome9/dome9-sdk-go/services/cloudaccounts

--- a/website/docs/d/cloudaccount_aws.html.markdown
+++ b/website/docs/d/cloudaccount_aws.html.markdown
@@ -38,3 +38,5 @@ In addition to all arguments above, the following attributes are exported:
 * `full_protection` - The tamper Protection mode for current security groups.
 * `allow_read_only` - The AWS cloud account operation mode. true for "Manage", false for "Readonly".
 * `net_sec` - The network security configuration for the AWS cloud account.
+* `organizational_unit_id` - Organizational unit id.
+

--- a/website/docs/r/cloudaccount_aws.html.markdown
+++ b/website/docs/r/cloudaccount_aws.html.markdown
@@ -23,6 +23,9 @@ resource "dome9_cloudaccount_aws" "test" {
     secret = "SECRET"
     type   = "RoleBased"
   }
+
+  organizational_unit_id = "ORGANIZATIONAL UNIT ID"
+
   net_sec {
     regions {
       new_group_behavior = "ReadOnly"
@@ -89,7 +92,6 @@ resource "dome9_cloudaccount_aws" "test" {
       region             = "eu_north_1"
     }
   }
-
 }
 ```
 
@@ -99,7 +101,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of AWS account in Dome9
 * `credentials` - (Required) The information needed for Dome9 System in order to connect to the AWS cloud account
-
+* `organizational_unit_id` - (Optional) The Organizational Unit that this cloud account will be attached to
 
 ### Credentials
 

--- a/website/docs/r/cloudaccount_azure.html.markdown
+++ b/website/docs/r/cloudaccount_azure.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `tenant_id` - (Required) The Azure tenant id
 * `operation_mode` - (Required) Dome9 operation mode for the Azure account ("Read-Only" or "Managed")
 * `credentials` - (Required) Azure account credentials
-* `organizational_unit_id` - Organizational unit id, will apply on update state
+* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
 
 ### Credentials
 

--- a/website/docs/r/cloudaccount_gcp.html.markdown
+++ b/website/docs/r/cloudaccount_gcp.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `gsuite_user` - (Optional) The gsuite user
 * `service_account_credentials` - (Required) The service account JSON block (from the GCP console)
 * `domain_name` - (Optional) The domain name
-* `organizational_unit_id` - (Optional) Organizational unit id, Will apply on update state
+* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
 
 ### Service Account Credentials
 


### PR DESCRIPTION
- Added support for OU association throughout create
- Update website docs

Resolves #24 

Tests remain unaffected:
```
=== RUN   TestAccDataSourceCloudAccountAWSBasic
--- PASS: TestAccDataSourceCloudAccountAWSBasic (3.66s)
=== RUN   TestAccDataSourceCloudAccountAzureBasic
--- PASS: TestAccDataSourceCloudAccountAzureBasic (3.30s)
=== RUN   TestAccDataSourceCloudAccountGCPBasic
--- PASS: TestAccDataSourceCloudAccountGCPBasic (3.49s)
=== RUN   TestAccDataSourceContinuousComplianceNotificationBasic
--- PASS: TestAccDataSourceContinuousComplianceNotificationBasic (1.82s)
=== RUN   TestAccDataSourceContinuousCompliancePolicyBasic
--- PASS: TestAccDataSourceContinuousCompliancePolicyBasic (4.75s)
=== RUN   TestAccDataSourceIpListBasic
--- PASS: TestAccDataSourceIpListBasic (2.15s)
=== RUN   TestAccDataSourceRuleSetBasic
--- PASS: TestAccDataSourceRuleSetBasic (2.98s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccResourceCloudAccountAWSBasic
--- PASS: TestAccResourceCloudAccountAWSBasic (6.55s)
=== RUN   TestAccResourceCloudAccountAzureBasic
--- PASS: TestAccResourceCloudAccountAzureBasic (4.84s)
=== RUN   TestAccResourceCloudAccountGCPBasic
--- PASS: TestAccResourceCloudAccountGCPBasic (5.50s)
=== RUN   TestAccResourceContinuousComplianceNotificationBasic
--- PASS: TestAccResourceContinuousComplianceNotificationBasic (3.62s)
=== RUN   TestAccResourceContinuousCompliancePolicyBasic
--- PASS: TestAccResourceContinuousCompliancePolicyBasic (7.37s)
=== RUN   TestAccResourceIPListBasic
--- PASS: TestAccResourceIPListBasic (4.22s)
=== RUN   TestAccResourceRuleSetBasic
--- PASS: TestAccResourceRuleSetBasic (3.66s)
PASS
```