### PR TITLE
Changing AWS security group resource name in testing

### DIFF
--- a/dome9/common/testing/variable/variable.go
+++ b/dome9/common/testing/variable/variable.go
@@ -64,7 +64,6 @@ const (
 
 // AWS security group resource/data source
 const (
-	AWSSecurityGroupName           = "test_aws_security_group"
 	AWSSecurityGroupDescription    = "this is aws security group test"
 	AWSSecurityGroupRegionID       = "us_east_1"
 	AWSSecurityGroupTagValue       = "tag_val_1"

--- a/dome9/resource_dome9_cloud_security_group_aws_test.go
+++ b/dome9/resource_dome9_cloud_security_group_aws_test.go
@@ -35,7 +35,7 @@ func TestAccResourceCloudSecurityGroupAWSBasic(t *testing.T) {
 				Config: testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsTypeAndName, securityGroupGeneratedName, securityGroupTypeAndName, variable.AWSSecurityGroupTagValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudSecurityGroupAWSExists(securityGroupTypeAndName, &cloudSecurityGroupAWSResponse),
-					resource.TestCheckResourceAttr(securityGroupTypeAndName, "dome9_security_group_name", variable.AWSSecurityGroupName),
+					resource.TestCheckResourceAttr(securityGroupTypeAndName, "dome9_security_group_name", securityGroupGeneratedName),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "description", variable.AWSSecurityGroupDescription),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "aws_region_id", variable.AWSSecurityGroupRegionID),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "tags.tag_key", variable.AWSSecurityGroupTagValue),
@@ -122,7 +122,7 @@ data "%s" "%s" {
 		// resource variables
 		resourcetype.CloudAccountAWSSecurityGroup,
 		securityGroupResourceName,
-		variable.AWSSecurityGroupName,
+		securityGroupResourceName,
 		variable.AWSSecurityGroupDescription,
 		variable.AWSSecurityGroupRegionID,
 		awsCloudAccountTypeAndName,


### PR DESCRIPTION
- Changing AWS security group resource name in testing

```
=== RUN   TestAccDataSourceCloudSecurityGroupAWSBasic
--- PASS: TestAccDataSourceCloudSecurityGroupAWSBasic (5.56s)
=== RUN   TestAccResourceCloudSecurityGroupAWSBasic
--- PASS: TestAccResourceCloudSecurityGroupAWSBasic (7.11s)
```