### PR TITLE
Azure resource re structure

### DIFF
--- a/dome9/resource_dome9_cloudaccount_azure.go
+++ b/dome9/resource_dome9_cloudaccount_azure.go
@@ -44,22 +44,14 @@ func resourceCloudAccountAzure() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"credentials": {
-				Type:     schema.TypeMap,
+			"client_id": {
+				Type:     schema.TypeString,
 				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"client_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"client_password": {
-							Type:      schema.TypeString,
-							Required:  true,
-							Sensitive: true,
-						},
-					},
-				},
+			},
+			"client_password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"creation_date": {
 				Type:     schema.TypeString,
@@ -116,7 +108,6 @@ func resourceCloudAccountAzureRead(d *schema.ResourceData, meta interface{}) err
 	_ = d.Set("name", resp.Name)
 	_ = d.Set("subscription_id", resp.SubscriptionID)
 	_ = d.Set("tenant_id", resp.TenantID)
-	_ = d.Set("credentials", resp.Credentials)
 	_ = d.Set("operation_mode", resp.OperationMode)
 	_ = d.Set("vendor", resp.Vendor)
 	_ = d.Set("creation_date", resp.CreationDate)
@@ -165,12 +156,12 @@ func resourceCloudAccountAzureUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if d.HasChange("credentials") {
+	if d.HasChange("client_id") || d.HasChange("client_password") {
 		log.Println("The credentials has been changed")
 
 		if resp, _, err := d9Client.cloudaccountAzure.UpdateCredentials(d.Id(), azure.CloudAccountUpdateCredentialsRequest{
-			ApplicationID:  d.Get("credentials.client_id").(string),
-			ApplicationKey: d.Get("credentials.client_password").(string),
+			ApplicationID:  d.Get("client_id").(string),
+			ApplicationKey: d.Get("client_password").(string),
 		}); err != nil {
 			return err
 		} else {
@@ -200,8 +191,8 @@ func expandCloudAccountAzureRequest(d *schema.ResourceData) azure.CloudAccountRe
 		TenantID:       d.Get("tenant_id").(string),
 		OperationMode:  d.Get("operation_mode").(string),
 		Credentials: azure.CloudAccountCredentials{
-			ClientID:       d.Get("credentials.client_id").(string),
-			ClientPassword: d.Get("credentials.client_password").(string),
+			ClientID:       d.Get("client_id").(string),
+			ClientPassword: d.Get("client_password").(string),
 		},
 		OrganizationalUnitID:   d.Get("organizational_unit_id").(string),
 		OrganizationalUnitPath: d.Get("organizational_unit_path").(string),

--- a/dome9/resource_dome9_cloudaccount_azure_test.go
+++ b/dome9/resource_dome9_cloudaccount_azure_test.go
@@ -138,15 +138,12 @@ data "%s" "%s" {
 func getCloudAccountAzureResourceHCL(cloudAccountName, generatedAName string) string {
 	return fmt.Sprintf(`
 resource "%s" "%s" {
-  credentials = {
-    client_id       = "%s"
-    client_password = "%s"
-  }
-
-  name            = "%s"
-  operation_mode  = "%s"
-  subscription_id = "%s"
-  tenant_id       = "%s"
+	client_id       = "%s"
+	client_password = "%s"
+	name            = "%s"
+	operation_mode  = "%s"
+	subscription_id = "%s"
+	tenant_id       = "%s"
 }
 `,
 		// azure cloud account variables

--- a/examples/cloudaccount/azure/main.tf
+++ b/examples/cloudaccount/azure/main.tf
@@ -1,9 +1,6 @@
 resource "dome9_cloudaccount_azure" "azure_ca" {
-  credentials = {
-    client_id       = "CLIENT_ID"
-    client_password = "CLIENT_PASSWORD"
-  }
-
+  client_id       = "CLIENT_ID"
+  client_password = "CLIENT_PASSWORD"
   name            = "sandbox"
   operation_mode  = "Read"
   subscription_id = "SUBSCRIPTION_ID"

--- a/website/docs/r/cloudaccount_azure.html.markdown
+++ b/website/docs/r/cloudaccount_azure.html.markdown
@@ -16,14 +16,12 @@ Basic usage:
 
 ```hcl
 resource "dome9_cloudaccount_azure" "test" {
-  name            = "NAME"
-  operation_mode  = "OPERATION MODE"
-  subscription_id = "SUBSCRIPTION ID"
-  tenant_id       = "TENANT ID"
-  credentials = {
-    client_id       = "CLIENT ID"
-    client_password = "CLIENT PASSWORD"
-  }
+  name                   = "NAME"
+  operation_mode         = "OPERATION MODE"
+  subscription_id        = "SUBSCRIPTION ID"
+  tenant_id              = "TENANT ID"
+  client_id              = "CLIENT ID"
+  client_password        = "CLIENT PASSWORD"
   organizational_unit_id = "ORGANIZATIONAL UNIT ID"
 }
 ```
@@ -33,18 +31,12 @@ resource "dome9_cloudaccount_azure" "test" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Azure account in Dome9
+* `operation_mode` - (Required) Dome9 operation mode for the Azure account ("Read-Only" or "Managed")
 * `subscription_id` - (Required) The Azure subscription id for account
 * `tenant_id` - (Required) The Azure tenant id
-* `operation_mode` - (Required) Dome9 operation mode for the Azure account ("Read-Only" or "Managed")
-* `credentials` - (Required) Azure account credentials
-* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
-
-### Credentials
-
-The `credentials` block supports: 
-
 * `client_id` - (Required) Azure account id
-* `client_password` - (Required) Password for account
+* `client_password` - (Required) Password for account* 
+* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Set client_password as sensitive field
Resolves #45 

Relevant tests output
```
=== RUN   TestAccDataSourceCloudAccountAzureBasic
--- PASS: TestAccDataSourceCloudAccountAzureBasic (4.37s)
=== RUN   TestAccResourceCloudAccountAzureBasic
--- PASS: TestAccResourceCloudAccountAzureBasic (4.26s)
```