### PR TITLE
GCP resource re structure

### DIFF
--- a/dome9/common/providerconst/const.go
+++ b/dome9/common/providerconst/const.go
@@ -13,6 +13,14 @@ const (
 	ProviderBaseURL   = "base_url"
 )
 
+// GCP onboarding
+const (
+	GCPCloudAccountType                    = "service_account"
+	GCPCloudAccountAuthUri                 = "https://accounts.google.com/o/oauth2/auth"
+	GCPCloudAccountTokenUri                = "https://oauth2.googleapis.com/token"
+	GCPCloudAccountAuthProviderX509CertUrl = "https://www.googleapis.com/oauth2/v1/certs"
+)
+
 // AWS security group protection mode
 const (
 	FullManage = "FullManage"

--- a/dome9/common/testing/variable/variable.go
+++ b/dome9/common/testing/variable/variable.go
@@ -21,13 +21,9 @@ const (
 
 // GCP resource/data source
 const (
-	CloudAccountGCPCreationResourceName    = "test_cloudaccount_gcp"
-	CloudAccountGCPUpdatedAccountName      = "updated_cloud_account_name"
-	CloudAccountGCPType                    = "service_account"
-	CloudAccountGCPVendor                  = "google"
-	CloudAccountGCPAuthURL                 = "https://accounts.google.com/o/oauth2/auth"
-	CloudAccountGCPTokenURL                = "https://oauth2.googleapis.com/token"
-	CloudAccountGCPAuthProviderX509CertURL = "https://www.googleapis.com/oauth2/v1/certs"
+	CloudAccountGCPCreationResourceName = "test_cloudaccount_gcp"
+	CloudAccountGCPUpdatedAccountName   = "updated_cloud_account_name"
+	CloudAccountGCPVendor               = "google"
 )
 
 // IpList resource/data source

--- a/dome9/resource_dome9_cloudaccount_gcp.go
+++ b/dome9/resource_dome9_cloudaccount_gcp.go
@@ -3,11 +3,12 @@ package dome9
 import (
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	"github.com/dome9/dome9-sdk-go/dome9/client"
 	"github.com/dome9/dome9-sdk-go/services/cloudaccounts"
 	"github.com/dome9/dome9-sdk-go/services/cloudaccounts/gcp"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-dome9/dome9/common/providerconst"
 )
 
 func resourceCloudAccountGCP() *schema.Resource {
@@ -24,55 +25,31 @@ func resourceCloudAccountGCP() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"service_account_credentials": {
-				Type:     schema.TypeMap,
+			"project_id": {
+				Type:     schema.TypeString,
 				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"project_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"private_key_id": {
-							Type:      schema.TypeString,
-							Required:  true,
-							Sensitive: true,
-						},
-						"private_key": {
-							Type:      schema.TypeString,
-							Required:  true,
-							Sensitive: true,
-						},
-						"client_email": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"client_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"auth_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"token_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"auth_provider_x509_cert_url": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"client_x509_cert_url": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
+			},
+			"private_key_id": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"private_key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"client_email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_x509_cert_url": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"vendor": {
 				Type:     schema.TypeString,
@@ -200,7 +177,7 @@ func resourceCloudAccountGCPUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if d.HasChange("service_account_credentials") {
+	if d.HasChange("project_id") || d.HasChange("private_key_id") || d.HasChange("private_key") || d.HasChange("client_email") || d.HasChange("client_id") || d.HasChange("client_x509_cert_url") {
 		log.Println("The service account credentials user or domain name has been changed")
 
 		if resp, _, err := d9Client.cloudaccountGCP.UpdateCredentials(d.Id(), gcp.CloudAccountUpdateCredentialsRequest{
@@ -230,15 +207,15 @@ func expandCloudAccountGCPRequest(d *schema.ResourceData) gcp.CloudAccountReques
 
 func expandServiceAccountCredentials(d *schema.ResourceData) gcp.ServiceAccountCredentials {
 	return gcp.ServiceAccountCredentials{
-		Type:                    d.Get("service_account_credentials.type").(string),
-		ProjectID:               d.Get("service_account_credentials.project_id").(string),
-		PrivateKeyID:            d.Get("service_account_credentials.private_key_id").(string),
-		PrivateKey:              d.Get("service_account_credentials.private_key").(string),
-		ClientEmail:             d.Get("service_account_credentials.client_email").(string),
-		ClientID:                d.Get("service_account_credentials.client_id").(string),
-		AuthURI:                 d.Get("service_account_credentials.auth_uri").(string),
-		TokenURI:                d.Get("service_account_credentials.token_uri").(string),
-		AuthProviderX509CertURL: d.Get("service_account_credentials.auth_provider_x509_cert_url").(string),
-		ClientX509CertURL:       d.Get("service_account_credentials.client_x509_cert_url").(string),
+		Type:                    providerconst.GCPCloudAccountType,
+		ProjectID:               d.Get("project_id").(string),
+		PrivateKeyID:            d.Get("private_key_id").(string),
+		PrivateKey:              d.Get("private_key").(string),
+		ClientEmail:             d.Get("client_email").(string),
+		ClientID:                d.Get("client_id").(string),
+		AuthURI:                 providerconst.GCPCloudAccountAuthUri,
+		TokenURI:                providerconst.GCPCloudAccountTokenUri,
+		AuthProviderX509CertURL: providerconst.GCPCloudAccountAuthProviderX509CertUrl,
+		ClientX509CertURL:       d.Get("client_x509_cert_url").(string),
 	}
 }

--- a/dome9/resource_dome9_cloudaccount_gcp.go
+++ b/dome9/resource_dome9_cloudaccount_gcp.go
@@ -177,7 +177,7 @@ func resourceCloudAccountGCPUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if d.HasChange("project_id") || d.HasChange("private_key_id") || d.HasChange("private_key") || d.HasChange("client_email") || d.HasChange("client_id") || d.HasChange("client_x509_cert_url") {
+	if credentialsHasChange(d) {
 		log.Println("The service account credentials user or domain name has been changed")
 
 		if resp, _, err := d9Client.cloudaccountGCP.UpdateCredentials(d.Id(), gcp.CloudAccountUpdateCredentialsRequest{
@@ -191,6 +191,10 @@ func resourceCloudAccountGCPUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+func credentialsHasChange(d *schema.ResourceData) bool {
+	return d.HasChange("project_id") || d.HasChange("private_key_id") || d.HasChange("private_key") || d.HasChange("client_email") || d.HasChange("client_id") || d.HasChange("client_x509_cert_url")
 }
 
 func expandCloudAccountGCPRequest(d *schema.ResourceData) gcp.CloudAccountRequest {

--- a/dome9/resource_dome9_cloudaccount_gcp_test.go
+++ b/dome9/resource_dome9_cloudaccount_gcp_test.go
@@ -119,19 +119,13 @@ func testAccCheckCloudAccountGCPExists(resource string, resp *gcp.CloudAccountRe
 func testAccCheckCloudAccountGCPConfigure(resourceTypeAndName, generatedName, resourceName string) string {
 	return fmt.Sprintf(`
 resource "%s" "%s" {
-  name = "%s"
-  service_account_credentials ={
-    type = "%s"
-    project_id = "%s"
-    private_key_id = "%s"
-    private_key = "%s"
-    client_email = "%s"
-    client_id = "%s"
-    auth_uri = "%s"
-    token_uri = "%s"
-    auth_provider_x509_cert_url = "%s"
-    client_x509_cert_url = "%s"
-  }
+  name                 = "%s"
+  project_id           = "%s"
+  private_key_id       = "%s"
+  private_key          = "%s"
+  client_email         = "%s"
+  client_id            = "%s"
+  client_x509_cert_url = "%s"
 }
 
 data "%s" "%s" {
@@ -142,15 +136,11 @@ data "%s" "%s" {
 		resourcetype.CloudAccountGCP,
 		generatedName,
 		resourceName,
-		variable.CloudAccountGCPType,
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarProjectId),
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarPrivateKeyId),
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarPrivateKey),
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarClientEmail),
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarClientId),
-		variable.CloudAccountGCPAuthURL,
-		variable.CloudAccountGCPTokenURL,
-		variable.CloudAccountGCPAuthProviderX509CertURL,
 		os.Getenv(environmentvariable.CloudAccountGCPEnvVarClientX509CertUrl),
 
 		// data source variables

--- a/examples/cloudaccount/gcp/main.tf
+++ b/examples/cloudaccount/gcp/main.tf
@@ -1,18 +1,11 @@
 resource "dome9_cloudaccount_gcp" "gcp_ca" {
-  name = "sandbox"
-
-  service_account_credentials = {
-    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
-    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
-    client_email                = "EMAIL@ADDRESS.COM"
-    client_id                   = "CID"
-    client_x509_cert_url        = "CERT URL"
-    private_key                 = "KEY"
-    private_key_id              = "PRIVATE"
-    project_id                  = "ID"
-    token_uri                   = "https://oauth2.googleapis.com/token"
-    type                        = "service_account"
-  }
+  name                        = "sandbox"
+  project_id                  = "ID"
+  private_key_id              = "PRIVATE"
+  private_key                 = "KEY"
+  client_email                = "EMAIL@ADDRESS.COM"
+  client_id                   = "CID"
+  auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
 }
 
 data "dome9_cloudaccount_gcp" "gcp_ds" {

--- a/examples/cloudaccount/gcp/main.tf
+++ b/examples/cloudaccount/gcp/main.tf
@@ -1,11 +1,11 @@
 resource "dome9_cloudaccount_gcp" "gcp_ca" {
-  name                        = "sandbox"
-  project_id                  = "ID"
-  private_key_id              = "PRIVATE"
-  private_key                 = "KEY"
-  client_email                = "EMAIL@ADDRESS.COM"
-  client_id                   = "CID"
-  auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+  name                 = "sandbox"
+  project_id           = "ID"
+  private_key_id       = "PRIVATE"
+  private_key          = "KEY"
+  client_email         = "EMAIL@ADDRESS.COM"
+  client_id            = "CID"
+  client_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
 }
 
 data "dome9_cloudaccount_gcp" "gcp_ds" {

--- a/website/docs/r/cloudaccount_gcp.html.markdown
+++ b/website/docs/r/cloudaccount_gcp.html.markdown
@@ -16,13 +16,13 @@ Basic usage:
 
 ```hcl
 resource "dome9_cloudaccount_gcp" "gcp_ca" {
-  name                        = "sandbox"
-  project_id                  = "ID"
-  private_key_id              = "PRIVATE"
-  private_key                 = "KEY"
-  client_email                = "EMAIL@ADDRESS.COM"
-  client_id                   = "CID"
-  auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+  name                 = "sandbox"
+  project_id           = "ID"
+  private_key_id       = "PRIVATE"
+  private_key          = "KEY"
+  client_email         = "EMAIL@ADDRESS.COM"
+  client_id            = "CID"
+  client_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
 }
 
 ```

--- a/website/docs/r/cloudaccount_gcp.html.markdown
+++ b/website/docs/r/cloudaccount_gcp.html.markdown
@@ -16,23 +16,13 @@ Basic usage:
 
 ```hcl
 resource "dome9_cloudaccount_gcp" "gcp_ca" {
-  name = "sandbox"
-
-  service_account_credentials = {
-    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
-    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
-    client_email                = "EMAIL@ADDRESS.COM"
-    client_id                   = "CID"
-    client_x509_cert_url        = "CERT URL"
-    private_key                 = "KEY"
-    private_key_id              = "PRIVATE"
-    project_id                  = "ID"
-    token_uri                   = "https://oauth2.googleapis.com/token"
-    type                        = "service_account"
-  }
-  gsuite_user = "GSUITE USER"
-  domain_name = "DOMAIN NAME"
-  organizational_unit_id = "ORGANIZATIONAL UNIT ID"
+  name                        = "sandbox"
+  project_id                  = "ID"
+  private_key_id              = "PRIVATE"
+  private_key                 = "KEY"
+  client_email                = "EMAIL@ADDRESS.COM"
+  client_id                   = "CID"
+  auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
 }
 
 ```
@@ -42,25 +32,15 @@ resource "dome9_cloudaccount_gcp" "gcp_ca" {
 The following arguments are supported:
 
 * `name` - (Required) Google account name in Dome9
-* `gsuite_user` - (Optional) The gsuite user
-* `service_account_credentials` - (Required) The service account JSON block (from the GCP console)
-* `domain_name` - (Optional) The domain name
-* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
-
-### Service Account Credentials
-
-The `service_account_credentials` block supports: 
-
-* `type` - (Required) type. i.e "service_account"
 * `project_id` - (Required) Project ID
 * `private_key_id` - (Required) Private key ID
 * `private_key` - (Required) Private key
 * `client_email` - (Required) GCP client email
 * `client_id` - (Required) Client id
-* `auth_uri` - (Required) Auth URI. i.e "https://accounts.google.com/o/oauth2/auth"
-* `token_uri` - (Required) Token URI. i.e "https://oauth2.googleapis.com/token"
-* `auth_provider_x509_cert_url` - (Required) auth_provider_x509_cert_url. i.e "https://www.googleapis.com/oauth2/v1/certs"
 * `client_x509_cert_url` - (Required) client_x509_cert_url
+* `gsuite_user` - (Optional) The gsuite user
+* `domain_name` - (Optional) The domain name
+* `organizational_unit_id` - (Optional) Organizational Unit that this cloud account will be attached to
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Set private_key_id as sensitive field.
- Set private_key as sensitive field.

Relevant tests output:
```
=== RUN   TestAccDataSourceCloudAccountGCPBasic
--- PASS: TestAccDataSourceCloudAccountGCPBasic (3.23s)
=== RUN   TestAccResourceCloudAccountGCPBasic
--- PASS: TestAccResourceCloudAccountGCPBasic (4.40s)
```