### PR TITLE
Remove tags from  AWS security group test

### DIFF
--- a/dome9/common/testing/variable/variable.go
+++ b/dome9/common/testing/variable/variable.go
@@ -65,7 +65,6 @@ const (
 const (
 	AWSSecurityGroupDescription = "this is aws security group test"
 	AWSSecurityGroupRegionID    = "us_east_1"
-	AWSSecurityGroupTagValue    = "tag_val_1"
 )
 
 // Azure security group resource/data source

--- a/dome9/data_source_dome9_cloud_security_group_aws_test.go
+++ b/dome9/data_source_dome9_cloud_security_group_aws_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceCloudSecurityGroupAWSBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsTypeAndName, resourceName, resourceTypeAndName, variable.AWSSecurityGroupTagValue),
+				Config: testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsTypeAndName, resourceName, resourceTypeAndName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "id", resourceTypeAndName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceTypeAndName, "dome9_security_group_name", resourceTypeAndName, "dome9_security_group_name"),

--- a/dome9/resource_dome9_cloud_security_group_aws_test.go
+++ b/dome9/resource_dome9_cloud_security_group_aws_test.go
@@ -32,13 +32,12 @@ func TestAccResourceCloudSecurityGroupAWSBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsTypeAndName, securityGroupGeneratedName, securityGroupTypeAndName, variable.AWSSecurityGroupTagValue),
+				Config: testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsTypeAndName, securityGroupGeneratedName, securityGroupTypeAndName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudSecurityGroupAWSExists(securityGroupTypeAndName, &cloudSecurityGroupAWSResponse),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "dome9_security_group_name", securityGroupGeneratedName),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "description", variable.AWSSecurityGroupDescription),
 					resource.TestCheckResourceAttr(securityGroupTypeAndName, "aws_region_id", variable.AWSSecurityGroupRegionID),
-					resource.TestCheckResourceAttr(securityGroupTypeAndName, "tags.tag_key", variable.AWSSecurityGroupTagValue),
 				),
 			},
 		},
@@ -88,7 +87,7 @@ func testAccCheckAWSCloudSecurityGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsCloudAccountTypeAndName, securityGroupResourceName, securityGroupTypeAndName, tagValue string) string {
+func testAccCheckCloudSecurityGroupAWSBasic(awsCloudAccountHCL, awsCloudAccountTypeAndName, securityGroupResourceName, securityGroupTypeAndName string) string {
 	return fmt.Sprintf(`
 // aws cloud account resource
 %s
@@ -100,9 +99,6 @@ resource "%s" "%s" {
   aws_region_id             = "%s"
   dome9_cloud_account_id    = "${%s.id}"
   is_protected              = true
-  tags = {
-    tag_key = "%s"
-  }
 }
 
 data "%s" "%s" {
@@ -118,7 +114,6 @@ data "%s" "%s" {
 		variable.AWSSecurityGroupDescription,
 		variable.AWSSecurityGroupRegionID,
 		awsCloudAccountTypeAndName,
-		tagValue,
 
 		// data source variables
 		resourcetype.CloudAccountAWSSecurityGroup,


### PR DESCRIPTION
- Remove tags from  AWS security group test.

Acceptance tests output:

```
=== RUN   TestAccDataSourceCloudSecurityGroupAWSBasic
--- PASS: TestAccDataSourceCloudSecurityGroupAWSBasic (5.04s)
=== RUN   TestAccResourceCloudSecurityGroupAWSBasic
--- PASS: TestAccResourceCloudSecurityGroupAWSBasic (5.39s)
```