### PR TITLE
Test for update Azure security group

### DIFF
--- a/dome9/common/testing/variable/variable.go
+++ b/dome9/common/testing/variable/variable.go
@@ -77,6 +77,11 @@ const (
 	AzureSecurityGroupRegion            = "australiaeast"
 	AzureSecurityGroupTagValue          = "tag_val_1"
 	AzureSecurityGroupIsTamperProtected = false
+
+	// 	update const
+	AzureSecurityGroupUpdateDescription       = "this is azure security group update test"
+	AzureSecurityGroupUpdateIsTamperProtected = true
+	AzureSecurityGroupUpdateTagValue          = "val"
 )
 
 // role resource/data source


### PR DESCRIPTION
- Test for update Azure security group

Relevant tests results:
```
=== RUN   TestAccDataSourceCloudSecurityGroupAzureBasic
--- PASS: TestAccDataSourceCloudSecurityGroupAzureBasic (30.20s)
=== RUN   TestAccResourceAzureSecurityGroupBasic
--- PASS: TestAccResourceAzureSecurityGroupBasic (79.53s)
```