### PR TITLE
ARN should be lowercase in this case

### DIFF
--- a/website/docs/r/cloudaccount_aws.html.markdown
+++ b/website/docs/r/cloudaccount_aws.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 
 `credentials` has the following arguments:
 
-* `ARN` - (Required) AWS Role ARN (to be assumed by Dome9)
+* `arn` - (Required) AWS Role ARN (to be assumed by Dome9)
 * `secret` - (Required) The AWS role External ID (Dome9  will have to use this secret in order to assume the role)
 * `type` - (Required) The cloud account onboarding method. Set to "RoleBased".
 


### PR DESCRIPTION
The credentials object seems to rather have lowercase `arn` in this case.