### PR TITLE
dome9_aws_security_group.external_id output fix

### DIFF
--- a/dome9/resource_dome9_cloud_security_group_aws.go
+++ b/dome9/resource_dome9_cloud_security_group_aws.go
@@ -226,7 +226,7 @@ func resourceCloudSecurityGroupAWSRead(d *schema.ResourceData, meta interface{})
 	_ = d.Set("is_protected", resp.IsProtected)
 	_ = d.Set("cloud_account_name", resp.CloudAccountName)
 	_ = d.Set("vpc_id", resp.VpcID)
-	_ = d.Set("external_id", resp.VpcID)
+	_ = d.Set("external_id", resp.ExternalID)
 	_ = d.Set("tags", resp.Tags)
 
 	if err := d.Set("services", flattenCloudSecurityGroupAWSServices(resp.Services)); err != nil {


### PR DESCRIPTION
dome9_aws_security_group.external_id returns the VPC ID, not the AWS Security Group ID. This PR should fix this behavior.