### PR TITLE
Fix AWS security group services ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.21.0 (Unreleased)
+## 1.21.0 (February 17, 2010)
+* IMPROVEMENTS:
+* Schema structure change for `data_aws_security_group`,`data_aws_security_group_rule`,`resource_dome9_aws_security_group`,`resource_dome9_aws_security_group_rule` ([#100](https://github.com/dome9/terraform-provider-dome9/pull/100))
+
 ## 1.20.1 (September 03, 2020)
 * IMPROVEMENTS:
     - Support new two aws regions: Cape Town (af-south-1) and Milan (eu-south-1) ([#90](https://github.com/terraform-providers/terraform-provider-dome9/pull/90))

--- a/dome9/data_source_dome9_cloud_security_group_aws.go
+++ b/dome9/data_source_dome9_cloud_security_group_aws.go
@@ -67,7 +67,7 @@ func dataSourceCloudSecurityGroupAWS() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"inbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -92,7 +92,7 @@ func dataSourceCloudSecurityGroupAWS() *schema.Resource {
 										Computed: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Computed: true,
 
 										Elem: &schema.Resource{
@@ -115,7 +115,7 @@ func dataSourceCloudSecurityGroupAWS() *schema.Resource {
 							},
 						},
 						"outbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -140,7 +140,7 @@ func dataSourceCloudSecurityGroupAWS() *schema.Resource {
 										Computed: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/dome9/data_source_dome9_cloud_security_group_aws_rule.go
+++ b/dome9/data_source_dome9_cloud_security_group_aws_rule.go
@@ -24,7 +24,7 @@ func dataSourceCloudSecurityGroupAWSRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"inbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -49,7 +49,7 @@ func dataSourceCloudSecurityGroupAWSRule() *schema.Resource {
 										Computed: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Computed: true,
 
 										Elem: &schema.Resource{
@@ -72,7 +72,7 @@ func dataSourceCloudSecurityGroupAWSRule() *schema.Resource {
 							},
 						},
 						"outbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -97,7 +97,7 @@ func dataSourceCloudSecurityGroupAWSRule() *schema.Resource {
 										Computed: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/dome9/resource_dome9_cloud_security_group_aws.go
+++ b/dome9/resource_dome9_cloud_security_group_aws.go
@@ -83,7 +83,7 @@ func resourceCloudSecurityGroupAWS() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"inbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -112,7 +112,7 @@ func resourceCloudSecurityGroupAWS() *schema.Resource {
 										Default:  false,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 
 										Elem: &schema.Resource{
@@ -135,7 +135,7 @@ func resourceCloudSecurityGroupAWS() *schema.Resource {
 							},
 						},
 						"outbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
 							Elem: &schema.Resource{
@@ -164,7 +164,7 @@ func resourceCloudSecurityGroupAWS() *schema.Resource {
 										Optional: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 										Computed: true,
 										Elem: &schema.Resource{
@@ -325,18 +325,18 @@ func expandServices(d *schema.ResourceData) *securitygroupaws.ServicesRequest {
 		service := servicesItem.(map[string]interface{})
 
 		return &securitygroupaws.ServicesRequest{
-			Inbound:  expandBoundServicesRequest(service["inbound"].([]interface{})),
-			Outbound: expandBoundServicesRequest(service["outbound"].([]interface{})),
+			Inbound:  expandBoundServicesRequest(service["inbound"].(*schema.Set)),
+			Outbound: expandBoundServicesRequest(service["outbound"].(*schema.Set)),
 		}
 	}
 
 	return nil
 }
 
-func expandBoundServicesRequest(boundServicesRequest []interface{}) []securitygroupaws.BoundServicesRequest {
-	boundServices := make([]securitygroupaws.BoundServicesRequest, len(boundServicesRequest))
+func expandBoundServicesRequest(boundServicesRequest *schema.Set) []securitygroupaws.BoundServicesRequest {
+	boundServices := make([]securitygroupaws.BoundServicesRequest, boundServicesRequest.Len())
 
-	for i, boundService := range boundServicesRequest {
+	for i, boundService := range boundServicesRequest.List() {
 		boundServiceItem := boundService.(map[string]interface{})
 
 		boundServices[i] = securitygroupaws.BoundServicesRequest{
@@ -345,16 +345,16 @@ func expandBoundServicesRequest(boundServicesRequest []interface{}) []securitygr
 			ProtocolType: boundServiceItem["protocol_type"].(string),
 			Port:         boundServiceItem["port"].(string),
 			OpenForAll:   boundServiceItem["open_for_all"].(bool),
-			Scope:        expandScope(boundServiceItem["scope"].([]interface{})),
+			Scope:        expandScope(boundServiceItem["scope"].(*schema.Set)),
 		}
 	}
 
 	return boundServices
 }
 
-func expandScope(scopeRequest []interface{}) []securitygroupaws.Scope {
-	scopes := make([]securitygroupaws.Scope, len(scopeRequest))
-	for i, scope := range scopeRequest {
+func expandScope(scopeRequest *schema.Set) []securitygroupaws.Scope {
+	scopes := make([]securitygroupaws.Scope, scopeRequest.Len())
+	for i, scope := range scopeRequest.List() {
 		scopeItem := scope.(map[string]interface{})
 		scopes[i] = securitygroupaws.Scope{
 			Type: scopeItem["type"].(string),

--- a/dome9/resource_dome9_cloud_security_group_aws_rule.go
+++ b/dome9/resource_dome9_cloud_security_group_aws_rule.go
@@ -34,7 +34,7 @@ func resourceCloudSecurityGroupAWSRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"inbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -63,7 +63,7 @@ func resourceCloudSecurityGroupAWSRule() *schema.Resource {
 										Default:  false,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 
 										Elem: &schema.Resource{
@@ -86,7 +86,7 @@ func resourceCloudSecurityGroupAWSRule() *schema.Resource {
 							},
 						},
 						"outbound": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
 							Elem: &schema.Resource{
@@ -115,7 +115,7 @@ func resourceCloudSecurityGroupAWSRule() *schema.Resource {
 										Optional: true,
 									},
 									"scope": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 										Computed: true,
 										Elem: &schema.Resource{


### PR DESCRIPTION
- Schema structure change TypeList -> TypeSet for 
- `data_aws_security_group`
- `data_aws_security_group_rule`
- `resource_dome9_aws_security_group`
- `resource_dome9_aws_security_group_rule` 
