### PR TITLE
AWS region ap_northeast_3 added

### DIFF
--- a/dome9/common/providerconst/const.go
+++ b/dome9/common/providerconst/const.go
@@ -72,6 +72,7 @@ const (
 	ME_SOUTH_1          = "25"
 	AF_SOUTH_1          = "26"
 	EU_SOUTH_1          = "27"
+	AP_NORTHEAST_3      = "28"
 )
 
 // Azure consts
@@ -80,8 +81,8 @@ var AzureSecurityGroupAccess = []string{"Allow", "Deny"}
 var AzureSecurityGroupProtocol = []string{"UDP", "TCP", "ANY"}
 var AzureSecurityGroupSourceScopeTypes = []string{"CIDR", "IPList", "Tag"}
 
-// The 20 regions Dome9 manages in AWS cloud account
-var AWSRegions = []string{"us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1"}
+// The 21 regions Dome9 manages in AWS cloud account
+var AWSRegions = []string{"us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3"}
 var CloudVendors = []string{"aws", "azure", "google"}
 var ProtocolTypes = []string{"ALL", "HOPOPT", "ICMP", "IGMP", "GGP", "IPV4", "ST", "TCP", "CBT", "EGP", "IGP", "BBN_RCC_MON", "NVP2", "PUP", "ARGUS", "EMCON", "XNET", "CHAOS", "UDP", "MUX", "DCN_MEAS", "HMP", "PRM", "XNS_IDP", "TRUNK1", "TRUNK2", "LEAF1", "LEAF2", "RDP", "IRTP", "ISO_TP4", "NETBLT", "MFE_NSP", "MERIT_INP", "DCCP", "ThreePC", "IDPR", "XTP", "DDP", "IDPR_CMTP", "TPplusplus", "IL", "IPV6", "SDRP", "IPV6_ROUTE", "IPV6_FRAG", "IDRP", "RSVP", "GRE", "DSR", "BNA", "ESP", "AH", "I_NLSP", "SWIPE", "NARP", "MOBILE", "TLSP", "SKIP", "ICMPV6", "IPV6_NONXT", "IPV6_OPTS", "CFTP", "SAT_EXPAK", "KRYPTOLAN", "RVD", "IPPC", "SAT_MON", "VISA", "IPCV", "CPNX", "CPHB", "WSN", "PVP", "BR_SAT_MON", "SUN_ND", "WB_MON", "WB_EXPAK", "ISO_IP", "VMTP", "SECURE_VMTP", "VINES", "TTP", "NSFNET_IGP", "DGP", "TCF", "EIGRP", "OSPFIGP", "SPRITE_RPC", "LARP", "MTP", "AX25", "IPIP", "MICP", "SCC_SP", "ETHERIP", "ENCAP", "GMTP", "IFMP", "PNNI", "PIM", "ARIS", "SCPS", "QNX", "AN", "IPCOMP", "SNP", "COMPAQ_PEER", "IPX_IN_IP", "VRRP", "PGM", "L2TP", "DDX", "IATP", "STP", "SRP", "UTI", "SMP", "SM", "PTP", "ISIS", "FIRE", "CRTP", "CRUDP", "SSCOPMCE", "IPLT", "SPS", "PIPE", "SCTP", "FC", "RSVP_E2E_IGNORE", "MOBILITY_HEADER", "UDPLITE", "MPLS_IN_IP", "MANET", "HIP", "SHIM6", "WESP", "ROHC"}
 var OperationMode = []string{"Read", "Manage"}
@@ -131,6 +132,7 @@ var AWSRegionsEnum = map[string]string{
 	"me_south_1":          ME_SOUTH_1,
 	"af_south_1":          AF_SOUTH_1,
 	"eu_south_1":          EU_SOUTH_1,
+	"ap_northeast_3":      AP_NORTHEAST_3,
 }
 
 var PermissionTrafficType = map[string]string{

--- a/dome9/resource_dome9_cloudaccount_aws_test.go
+++ b/dome9/resource_dome9_cloudaccount_aws_test.go
@@ -249,6 +249,10 @@ net_sec {
       new_group_behavior = "ReadOnly"
       region             = "eu_south_1"
     }
+	regions {
+		new_group_behavior = "ReadOnly"
+		region             = "ap_northeast_3"
+	  }
   }
 `,
 		groupBehavior,

--- a/website/docs/r/cloudaccount_aws.html.markdown
+++ b/website/docs/r/cloudaccount_aws.html.markdown
@@ -99,13 +99,17 @@ resource "dome9_cloudaccount_AWS" "test" {
       new_group_behavior = "ReadOnly"
       region             = "me_south_1"
     }
-	regions {
+    regions {
       new_group_behavior = "ReadOnly"
       region             = "af_south_1"
     }
-	regions {
+    regions {
       new_group_behavior = "ReadOnly"
       region             = "eu_south_1"
+    }
+    regions {
+      new_group_behavior = "ReadOnly"
+      region             = "ap_northeast_3"
     }
   }
 }


### PR DESCRIPTION
It seems that ap_northeast_3 was added to the Dome9 platform but not yet added to the provider. Because of this, we see constant drifts in our TF plans like:

```
# module.dome9.dome9_cloudaccount_aws.account will be updated in-place
  ~ resource "dome9_cloudaccount_aws" "account" {
        id                      = "<id>"
        name                    = "<name>"
        # (8 unchanged attributes hidden)

      ~ net_sec {
          - regions {
              - hidden             = true -> null
              - name               = "Osaka" -> null
              - new_group_behavior = "ReadOnly" -> null
              - region             = "ap_northeast_3" -> null
            }
            # (20 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }
```