### PR TITLE
dome9_cloud_security_group.external_id fix

### DIFF
--- a/dome9/data_source_dome9_cloud_security_group_aws.go
+++ b/dome9/data_source_dome9_cloud_security_group_aws.go
@@ -187,7 +187,7 @@ func dataSourceSecurityGroupAWSRead(d *schema.ResourceData, meta interface{}) er
 	_ = d.Set("is_protected", resp.IsProtected)
 	_ = d.Set("cloud_account_name", resp.CloudAccountName)
 	_ = d.Set("vpc_id", resp.VpcID)
-	_ = d.Set("external_id", resp.VpcID)
+	_ = d.Set("external_id", resp.ExternalID)
 	_ = d.Set("tags", resp.Tags)
 	_ = d.Set("services", flattenCloudSecurityGroupAWSServices(resp.Services))
 


### PR DESCRIPTION
`data.dome9_cloud_security_group.external_id` should contain the AWS Security Group ID, not the VPC id.