### PR TITLE
Fix/add me central 1 region to dome9

### DIFF
--- a/dome9/common/providerconst/const.go
+++ b/dome9/common/providerconst/const.go
@@ -109,6 +109,7 @@ const (
 	AF_SOUTH_1          = "26"
 	EU_SOUTH_1          = "27"
 	AP_NORTHEAST_3      = "28"
+	ME_CENTRAL_1	    = "29"
 )
 
 // Azure consts

--- a/dome9/resource_dome9_cloudaccount_aws_test.go
+++ b/dome9/resource_dome9_cloudaccount_aws_test.go
@@ -253,6 +253,10 @@ net_sec {
       new_group_behavior = "ReadOnly"
       region             = "ap_northeast_3"
     }
+        regions {
+      new_group_behavior = "ReadOnly"
+      region             = "me_central_1"
+    }
   }
 `,
 		groupBehavior,

--- a/website/docs/r/cloudaccount_aws.html.markdown
+++ b/website/docs/r/cloudaccount_aws.html.markdown
@@ -111,6 +111,10 @@ resource "dome9_cloudaccount_aws" "test" {
       new_group_behavior = "ReadOnly"
       region             = "ap_northeast_3"
     }
+    regions {
+      new_group_behavior = "ReadOnly"
+      region             = "me_central_1"
+    }
   }
 }
 ```


### PR DESCRIPTION
![dome9_error](https://github.com/dome9/terraform-provider-dome9/assets/34864946/c44e9354-80f7-4277-b32c-990dd5256b1d)

We have an error in our deployments because the region me_central_1 it was added and it is not present in the provider.
This is my PR for add this region to the new provider.

Thanks!