### PR TITLE
Fix new region names

### DIFF
--- a/dome9/common/providerconst/const.go
+++ b/dome9/common/providerconst/const.go
@@ -124,7 +124,7 @@ var AzureSecurityGroupProtocol = []string{"UDP", "TCP", "ANY"}
 var AzureSecurityGroupSourceScopeTypes = []string{"CIDR", "IPList", "Tag"}
 
 // The 21 regions Dome9 manages in AWS cloud account
-var AWSRegions = []string{"us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me-central-1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "eu-central-2", "eu-south-2"}
+var AWSRegions = []string{"us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me_central_1", "ap_south_2", "ap_southeast_3", "ap_southeast_4", "eu_central_2", "eu_south_2"}
 
 // The 2 regions Dome9 manages in AWSGOV cloud account
 var AWSGOVRegions = []string{"us_gov_west_1", "us_gov_east_1"}

--- a/website/docs/d/role.html.markdown
+++ b/website/docs/d/role.html.markdown
@@ -45,6 +45,6 @@ In addition to all arguments above, the following attributes are exported:
 ### SRL 
 * `type` - (Optional) Accepted values: AWS, Azure, GCP, OrganizationalUnit.
 * `main_id` - (Optional) Cloud Account or Organizational Unit ID.
-* `region` - (Optional) Accepted values: "us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me_central_1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "eu-central-2", "eu-south-2".
+* `region` - (Optional) Accepted values: "us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me_central_1", "ap_south_2", "ap_southeast_3", "ap_southeast_4", "eu_central_2", "eu_south_2".
 * `security_group_id` - (Optional) AWS Security Group ID.
 * `traffic` - (Optional) Accepted values: "All Traffic", "All Services".

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -70,6 +70,6 @@ In addition to all arguments above, the following attributes are exported:
 ### SRL 
 * `type` - (Optional) Accepted values: AWS, Azure, GCP, OrganizationalUnit.
 * `main_id` - (Optional) Cloud Account or Organizational Unit ID.
-* `region` - (Optional) Accepted values: "us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me_central_1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "eu-central-2", "eu-south-2".
+* `region` - (Optional) Accepted values: "us_east_1", "us_west_1", "eu_west_1", "ap_southeast_1", "ap_northeast_1", "us_west_2", "sa_east_1", "ap_southeast_2", "eu_central_1", "ap_northeast_2", "ap_south_1", "us_east_2", "ca_central_1", "eu_west_2", "eu_west_3", "eu_north_1", "ap_east_1", "me_south_1", "af_south_1", "eu_south_1", "ap_northeast_3", "me_central_1", "ap_south_2", "ap_southeast_3", "ap_southeast_4", "eu_central_2", "eu_south_2".
 * `security_group_id` - (Optional) AWS Security Group ID.
 * `traffic` - (Optional) Accepted values: "All Traffic", "All Services".


### PR DESCRIPTION
The regions that were added in the last release have a typo in them where they were typed as me-central-1 but the format  me_central_1. 